### PR TITLE
Fix DropSetView preview dependency

### DIFF
--- a/FitLink/UIAtoms/WorkoutScreen/DropSetView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/DropSetView.swift
@@ -101,8 +101,10 @@ let mockDropSetSteps = [
     )
 ]
 
+let sampleApproach = DropSetApproach(steps: mockDropSetSteps)
+
 let mockDropSetApproaches = [
-    DropSetApproach(steps: mockDropSetSteps)
+    sampleApproach
 ]
 
 // Пример ExerciseInstance для превью
@@ -120,7 +122,7 @@ let mockDropSetInstance = ExerciseInstance(
             ExerciseMetric(type: .weight, isRequired: true)
         ]
     ),
-    approaches: [dropSetApproach1],
+    approaches: [sampleApproach],
     groupId: nil,
     notes: nil
 )


### PR DESCRIPTION
## Summary
- update DropSetView preview mocks to use a local `DropSetApproach`

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*
- `swiftc -typecheck FitLink/UIAtoms/WorkoutScreen/DropSetView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684062eb2a908330a76fbecb1ac5345e