### PR TITLE
Add basic localization

### DIFF
--- a/FitLink/CommonServices/DateFormatterService.swift
+++ b/FitLink/CommonServices/DateFormatterService.swift
@@ -36,9 +36,9 @@ final class DateFormatterService {
     /// "Сегодня", "Вчера", "30 мая 2025"
     func formattedDate(_ date: Date) -> String {
         if Calendar.current.isDateInToday(date) {
-            return "Сегодня"
+            return NSLocalizedString("DateFormatter.Today", comment: "Сегодня")
         } else if Calendar.current.isDateInYesterday(date) {
-            return "Вчера"
+            return NSLocalizedString("DateFormatter.Yesterday", comment: "Вчера")
         } else {
             return dateFormatter.string(from: date)
         }

--- a/FitLink/Helpers/Date+Ext.swift
+++ b/FitLink/Helpers/Date+Ext.swift
@@ -10,10 +10,10 @@ import Foundation
 extension Date {
     func timeAgoDisplay() -> String {
         let calendar = Calendar.current
-        if calendar.isDateInToday(self) { return "сегодня" }
-        if calendar.isDateInYesterday(self) { return "вчера" }
+        if calendar.isDateInToday(self) { return NSLocalizedString("DateExtensions.Today", comment: "сегодня") }
+        if calendar.isDateInYesterday(self) { return NSLocalizedString("DateExtensions.Yesterday", comment: "вчера") }
         let days = calendar.dateComponents([.day], from: self, to: Date()).day ?? 0
-        return "\(days) дн. назад"
+        return "\(days) " + NSLocalizedString("DateExtensions.DaysAgoSuffix", comment: "дн. назад")
     }
     
     func formattedShort() -> String {

--- a/FitLink/Localization/Localizable.strings
+++ b/FitLink/Localization/Localizable.strings
@@ -1,0 +1,133 @@
+/* WorkoutSession header with client name */
+"WorkoutSession.Header" = "Тренировка для %@";
+"WorkoutSession.ClientPlaceholder" = "Клиента";
+"WorkoutSession.Title" = "Тренировка";
+
+/* Schedule screen */
+"Schedule.Header" = "Занятия";
+"Schedule.SearchPlaceholder" = "Search clients...";
+
+/* Exercise library */
+"ExerciseLibrary.Header" = "Упражнения";
+"ExerciseLibrary.SearchPlaceholder" = "Поиск упражнения...";
+"ExerciseLibrary.FilterTitle" = "Выберите группу мышц";
+"ExerciseLibrary.FilterAll" = "Все";
+
+/* Dashboard */
+"Dashboard.Greeting" = "Привет, Юрий!";
+"Dashboard.SearchPlaceholder" = "Поиск клиента...";
+"Dashboard.FilterTitle" = "Фильтровать по";
+"Dashboard.Filter.None" = "Очистить фильтр";
+"Dashboard.Filter.NextSessionDate" = "По дате следующей тренировки";
+"Dashboard.Filter.NextSessionType" = "По типу тренировки";
+"Dashboard.Stats.TotalClients" = "Всего клиентов";
+"Dashboard.Stats.InProgress" = "Идёт сейчас";
+"Dashboard.Stats.Feedback" = "Отзывов";
+
+/* Main tabs */
+"Main.Tab.Dashboard" = "Dashboard";
+"Main.Tab.Exercises" = "Exercises";
+"Main.Tab.Schedule" = "Schedule";
+"Main.Tab.Workouts" = "Workouts";
+"Main.Tab.Profile" = "Profile";
+
+/* Schedule calendar */
+"ScheduleCalendar.Empty" = "Нет занятий на эту дату";
+
+/* Schedule list */
+"ScheduleList.TodayTitle" = "Сессии на сегодня";
+"ScheduleList.NewSession" = "Новая сессия";
+"ScheduleList.Empty" = "Нет сессий на сегодня";
+
+/* Calendar mode */
+"CalendarMode.AddSession" = "Добавить сессию";
+"CalendarMode.Empty" = "Нет запланированных сессий";
+"Calendar.MoreIndicator" = "+";
+
+/* Client row */
+"ClientRow.LastSession" = "Последняя: %@ • %@";
+"ClientRow.NextSession" = "Следующая: %@ • %@";
+
+/* Exercise set row */
+"ExerciseSetRow.SetTitle" = "Сет %d:";
+"ExerciseSetRow.ActualTitle" = "Факт:";
+"ExerciseSetRow.RPE" = "RPE:";
+"ExerciseSetRow.NotePlaceholder" = "Заметка к сету";
+
+/* Approach set view */
+"ApproachSetView.Title" = "Подход %d:";
+"ApproachSetView.DropLabel" = "Дроп %d:";
+
+/* Drop set view */
+"DropSetView.Title" = "Подход %d";
+"DropSetView.MainStep" = "Основной";
+"DropSetView.DropStep" = "Дроп %d";
+
+/* Superset approach view */
+"SupersetApproachView.Title" = "Подход %d";
+
+/* Workout set group */
+"WorkoutSetGroup.RepsMultiplier" = "×%d";
+"WorkoutSetGroup.EmptySuperset" = "Нет подходов в суперсете";
+"WorkoutSetGroup.EmptyDropset" = "Нет дропсета";
+
+/* Search bar */
+"SearchBar.DefaultPlaceholder" = "Search...";
+
+/* Date formatter */
+"DateFormatter.Today" = "Сегодня";
+"DateFormatter.Yesterday" = "Вчера";
+
+/* Date extensions */
+"DateExtensions.Today" = "сегодня";
+"DateExtensions.Yesterday" = "вчера";
+"DateExtensions.DaysAgoSuffix" = "дн. назад";
+
+/* Client model */
+"ClientModel.PlaceholderName" = "Клиент";
+
+/* Session status labels */
+"SessionStatus.PlannedLabel" = "Запланировано";
+"SessionStatus.InProgressLabel" = "В процессе";
+"SessionStatus.CompletedLabel" = "Выполнено";
+"SessionStatus.CancelledLabel" = "Отменено";
+
+/* Set group types */
+"SetGroupType.Superset" = "Суперсет";
+"SetGroupType.Dropset" = "Дропсет";
+"SetGroupType.Circuit" = "Круг";
+"SetGroupType.Pyramid" = "Пирамида";
+
+/* Exercise metric types */
+"ExerciseMetricType.Reps" = "Повторы";
+"ExerciseMetricType.Weight" = "Вес";
+"ExerciseMetricType.Time" = "Время";
+"ExerciseMetricType.Distance" = "Дистанция";
+"ExerciseMetricType.Calories" = "Калории";
+
+/* Unit types */
+"UnitType.Kilogram" = "кг";
+"UnitType.Pound" = "фунты";
+"UnitType.Second" = "сек";
+"UnitType.Minute" = "мин";
+"UnitType.Meter" = "м";
+"UnitType.Kilometer" = "км";
+"UnitType.Repetition" = "повт.";
+"UnitType.Calorie" = "ккал";
+
+/* Muscle groups */
+"MuscleGroup.Chest" = "Грудные";
+"MuscleGroup.Back" = "Спина";
+"MuscleGroup.Shoulders" = "Плечи";
+"MuscleGroup.Biceps" = "Бицепс";
+"MuscleGroup.Triceps" = "Трицепс";
+"MuscleGroup.Legs" = "Ноги";
+"MuscleGroup.Glutes" = "Ягодицы";
+"MuscleGroup.Abs" = "Пресс";
+"MuscleGroup.Core" = "Кор";
+"MuscleGroup.Calves" = "Икры";
+"MuscleGroup.Forearms" = "Предплечья";
+"MuscleGroup.Traps" = "Трапеции";
+"MuscleGroup.Cardio" = "Кардио";
+"MuscleGroup.Mobility" = "Мобильность";
+"MuscleGroup.FullBody" = "Всё тело";

--- a/FitLink/Models/Client.swift
+++ b/FitLink/Models/Client.swift
@@ -22,7 +22,7 @@ struct Client: Identifiable, Hashable {
 extension Client {
     static let placeholder = Client(
         id: UUID(),
-        name: "Клиент",
+        name: NSLocalizedString("ClientModel.PlaceholderName", comment: "Клиент"),
         avatarURL: nil
     )
 }

--- a/FitLink/Models/Exercise/ExerciseMetric.swift
+++ b/FitLink/Models/Exercise/ExerciseMetric.swift
@@ -41,12 +41,18 @@ enum ExerciseMetricType: Codable, CaseIterable, Equatable, Hashable {
 
     var displayName: String {
         switch self {
-        case .reps: return "Повторы"
-        case .weight: return "Вес"
-        case .time: return "Время"
-        case .distance: return "Дистанция"
-        case .calories: return "Калории"
-        case .custom(let value): return value
+        case .reps:
+            return NSLocalizedString("ExerciseMetricType.Reps", comment: "Повторы")
+        case .weight:
+            return NSLocalizedString("ExerciseMetricType.Weight", comment: "Вес")
+        case .time:
+            return NSLocalizedString("ExerciseMetricType.Time", comment: "Время")
+        case .distance:
+            return NSLocalizedString("ExerciseMetricType.Distance", comment: "Дистанция")
+        case .calories:
+            return NSLocalizedString("ExerciseMetricType.Calories", comment: "Калории")
+        case .custom(let value):
+            return value
         }
     }
     
@@ -82,15 +88,24 @@ enum UnitType: Codable, CaseIterable, Equatable, Hashable {
 
     var displayName: String {
         switch self {
-        case .kilogram: return "кг"
-        case .pound: return "фунты"
-        case .second: return "сек"
-        case .minute: return "мин"
-        case .meter: return "м"
-        case .kilometer: return "км"
-        case .repetition: return "повт."
-        case .calorie: return "ккал"
-        case .custom(let value): return value
+        case .kilogram:
+            return NSLocalizedString("UnitType.Kilogram", comment: "кг")
+        case .pound:
+            return NSLocalizedString("UnitType.Pound", comment: "фунты")
+        case .second:
+            return NSLocalizedString("UnitType.Second", comment: "сек")
+        case .minute:
+            return NSLocalizedString("UnitType.Minute", comment: "мин")
+        case .meter:
+            return NSLocalizedString("UnitType.Meter", comment: "м")
+        case .kilometer:
+            return NSLocalizedString("UnitType.Kilometer", comment: "км")
+        case .repetition:
+            return NSLocalizedString("UnitType.Repetition", comment: "повт.")
+        case .calorie:
+            return NSLocalizedString("UnitType.Calorie", comment: "ккал")
+        case .custom(let value):
+            return value
         }
     }
     

--- a/FitLink/Models/Exercise/MuscleGroup.swift
+++ b/FitLink/Models/Exercise/MuscleGroup.swift
@@ -27,22 +27,38 @@ enum MuscleGroup: Codable, Equatable, Hashable {
 
     var displayName: String {
         switch self {
-        case .chest: return "Грудные"
-        case .back: return "Спина"
-        case .shoulders: return "Плечи"
-        case .biceps: return "Бицепс"
-        case .triceps: return "Трицепс"
-        case .legs: return "Ноги"
-        case .glutes: return "Ягодицы"
-        case .abs: return "Пресс"
-        case .core: return "Кор"
-        case .calves: return "Икры"
-        case .forearms: return "Предплечья"
-        case .traps: return "Трапеции"
-        case .cardio: return "Кардио"
-        case .mobility: return "Мобильность"
-        case .fullBody: return "Всё тело"
-        case .custom(let value): return value
+        case .chest:
+            return NSLocalizedString("MuscleGroup.Chest", comment: "Грудные")
+        case .back:
+            return NSLocalizedString("MuscleGroup.Back", comment: "Спина")
+        case .shoulders:
+            return NSLocalizedString("MuscleGroup.Shoulders", comment: "Плечи")
+        case .biceps:
+            return NSLocalizedString("MuscleGroup.Biceps", comment: "Бицепс")
+        case .triceps:
+            return NSLocalizedString("MuscleGroup.Triceps", comment: "Трицепс")
+        case .legs:
+            return NSLocalizedString("MuscleGroup.Legs", comment: "Ноги")
+        case .glutes:
+            return NSLocalizedString("MuscleGroup.Glutes", comment: "Ягодицы")
+        case .abs:
+            return NSLocalizedString("MuscleGroup.Abs", comment: "Пресс")
+        case .core:
+            return NSLocalizedString("MuscleGroup.Core", comment: "Кор")
+        case .calves:
+            return NSLocalizedString("MuscleGroup.Calves", comment: "Икры")
+        case .forearms:
+            return NSLocalizedString("MuscleGroup.Forearms", comment: "Предплечья")
+        case .traps:
+            return NSLocalizedString("MuscleGroup.Traps", comment: "Трапеции")
+        case .cardio:
+            return NSLocalizedString("MuscleGroup.Cardio", comment: "Кардио")
+        case .mobility:
+            return NSLocalizedString("MuscleGroup.Mobility", comment: "Мобильность")
+        case .fullBody:
+            return NSLocalizedString("MuscleGroup.FullBody", comment: "Всё тело")
+        case .custom(let value):
+            return value
         }
     }
 

--- a/FitLink/Models/Workout/SetGroupType.swift
+++ b/FitLink/Models/Workout/SetGroupType.swift
@@ -17,11 +17,16 @@ enum SetGroupType: Codable, Equatable, Hashable {
 
     var displayName: String {
         switch self {
-        case .superset: return "Суперсет"
-        case .dropset: return "Дропсет"
-        case .circuit: return "Круг"
-        case .pyramid: return "Пирамида"
-        case .custom(let value): return value
+        case .superset:
+            return NSLocalizedString("SetGroupType.Superset", comment: "Суперсет")
+        case .dropset:
+            return NSLocalizedString("SetGroupType.Dropset", comment: "Дропсет")
+        case .circuit:
+            return NSLocalizedString("SetGroupType.Circuit", comment: "Круг")
+        case .pyramid:
+            return NSLocalizedString("SetGroupType.Pyramid", comment: "Пирамида")
+        case .custom(let value):
+            return value
         }
     }
 

--- a/FitLink/Models/Workout/WorkoutSession.swift
+++ b/FitLink/Models/Workout/WorkoutSession.swift
@@ -37,10 +37,14 @@ enum SessionStatus: String, Codable, CaseIterable, Hashable {
 
     var labelText: String {
         switch self {
-        case .planned: return "Запланировано"
-        case .inProgress: return "В процессе"
-        case .completed: return "Выполнено"
-        case .cancelled: return "Отменено"
+        case .planned:
+            return NSLocalizedString("SessionStatus.PlannedLabel", comment: "Запланировано")
+        case .inProgress:
+            return NSLocalizedString("SessionStatus.InProgressLabel", comment: "В процессе")
+        case .completed:
+            return NSLocalizedString("SessionStatus.CompletedLabel", comment: "Выполнено")
+        case .cancelled:
+            return NSLocalizedString("SessionStatus.CancelledLabel", comment: "Отменено")
         }
     }
     

--- a/FitLink/UIAtoms/Calendar/CalendarModeView.swift
+++ b/FitLink/UIAtoms/Calendar/CalendarModeView.swift
@@ -32,7 +32,7 @@ struct CalendarModeView: View {
                 Button(action: {
                     // Добавить сессию на выбранную дату
                 }) {
-                    Label("Добавить сессию", systemImage: "plus")
+                    Label(NSLocalizedString("CalendarMode.AddSession", comment: "Добавить сессию"), systemImage: "plus")
                         .font(.subheadline.bold())
                         .foregroundColor(.blue)
                 }
@@ -41,7 +41,7 @@ struct CalendarModeView: View {
             .padding(.bottom, 16)
 
             if filteredSessions.isEmpty {
-                Text("Нет запланированных сессий")
+                Text(NSLocalizedString("CalendarMode.Empty", comment: "Нет запланированных сессий"))
                     .foregroundColor(.gray)
                     .padding()
             } else {

--- a/FitLink/UIAtoms/Calendar/CustomCalendarView.swift
+++ b/FitLink/UIAtoms/Calendar/CustomCalendarView.swift
@@ -93,7 +93,7 @@ struct CustomCalendarView: View {
                                         .frame(width: 6, height: 6)
                                 }
                                 if colors.count > 3 {
-                                    Text("+")
+                                    Text(NSLocalizedString("Calendar.MoreIndicator", comment: "+"))
                                         .font(.caption2)
                                         .foregroundColor(.gray)
                                 }

--- a/FitLink/UIAtoms/Calendar/ListModelView.swift
+++ b/FitLink/UIAtoms/Calendar/ListModelView.swift
@@ -15,13 +15,13 @@ struct ListModeView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
-                Text("Сессии на сегодня")
+                Text(NSLocalizedString("ScheduleList.TodayTitle", comment: "Сессии на сегодня"))
                     .font(.headline)
                 Spacer()
                 Button(action: {
                     // Новая сессия на сегодня
                 }) {
-                    Label("Новая сессия", systemImage: "plus")
+                    Label(NSLocalizedString("ScheduleList.NewSession", comment: "Новая сессия"), systemImage: "plus")
                         .font(.subheadline.bold())
                         .foregroundColor(.blue)
                 }
@@ -30,7 +30,7 @@ struct ListModeView: View {
             .padding(.bottom, 16)
 
             if todaySessions.isEmpty {
-                Text("Нет сессий на сегодня")
+                Text(NSLocalizedString("ScheduleList.Empty", comment: "Нет сессий на сегодня"))
                     .foregroundColor(.gray)
                     .padding()
             } else {

--- a/FitLink/UIAtoms/ClientRow.swift
+++ b/FitLink/UIAtoms/ClientRow.swift
@@ -23,13 +23,13 @@ struct ClientRow: View {
                     .foregroundColor(.primary)
                 
                 if let lastSession = lastSession {
-                    Text("Последняя: \(lastSession.timeString) • \(lastSession.date?.formattedHuman() ?? "")")
+                    Text(String(format: NSLocalizedString("ClientRow.LastSession", comment: "Последняя: %@ • %@"), lastSession.timeString, lastSession.date?.formattedHuman() ?? ""))
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
                 
                 if let nextSession = nextSession {
-                    Text("Следующая: \(nextSession.timeString) • \(nextSession.date?.formattedHuman() ?? "")")
+                    Text(String(format: NSLocalizedString("ClientRow.NextSession", comment: "Следующая: %@ • %@"), nextSession.timeString, nextSession.date?.formattedHuman() ?? ""))
                         .font(.caption)
                         .foregroundColor(Color(.label))
                         .padding(.vertical, 2)

--- a/FitLink/UIAtoms/ScheduleCalendarContainer.swift
+++ b/FitLink/UIAtoms/ScheduleCalendarContainer.swift
@@ -35,7 +35,7 @@ struct ScheduleCalendarContainer: View {
 
             let daySessions = viewModel.sessionsByDate[Calendar.current.startOfDay(for: viewModel.selectedDate)] ?? []
             if daySessions.isEmpty {
-                Text("Нет занятий на эту дату")
+                Text(NSLocalizedString("ScheduleCalendar.Empty", comment: "Нет занятий на эту дату"))
                     .foregroundColor(.gray)
                     .padding()
             } else {

--- a/FitLink/UIAtoms/SearchBarWithFilter.swift
+++ b/FitLink/UIAtoms/SearchBarWithFilter.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SearchBarWithFilter: View {
     @Binding var text: String
     @FocusState private var isFocused: Bool
-    var placeholder: String = "Search..."
+    var placeholder: String = NSLocalizedString("SearchBar.DefaultPlaceholder", comment: "Search...")
     var onFilterTapped: (() -> Void)? = nil
 
     var body: some View {

--- a/FitLink/UIAtoms/WorkoutScreen/ApproachSetView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachSetView.swift
@@ -16,7 +16,7 @@ struct ApproachSetView: View {
         VStack(alignment: .leading, spacing: 4) {
             // Основной сет
             HStack {
-                Text("Подход \(index + 1):")
+                Text(String(format: NSLocalizedString("ApproachSetView.Title", comment: "Подход %d:"), index + 1))
                     .font(.body)
                     .foregroundColor(.primary)
                 Spacer()
@@ -44,7 +44,7 @@ struct ApproachSetView: View {
                         Circle()
                             .fill(Color.orange.opacity(0.5))
                             .frame(width: 8, height: 8)
-                        Text("Дроп \(i + 1):")
+                        Text(String(format: NSLocalizedString("ApproachSetView.DropLabel", comment: "Дроп %d:"), i + 1))
                             .font(.caption2)
                             .foregroundColor(.orange)
                             .frame(width: 60, alignment: .leading)

--- a/FitLink/UIAtoms/WorkoutScreen/DropSetView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/DropSetView.swift
@@ -15,7 +15,7 @@ struct DropSetView: View {
             ForEach(Array(approaches.enumerated()), id: \.element.id) { idx, app in
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(alignment: .firstTextBaseline) {
-                        Text("Подход \(idx + 1)")
+                        Text(String(format: NSLocalizedString("DropSetView.Title", comment: "Подход %d"), idx + 1))
                             .font(.headline)
                             .foregroundColor(.orange)
                             .padding(.bottom, 6)
@@ -27,7 +27,7 @@ struct DropSetView: View {
                             Circle()
                                 .fill(i == 0 ? Color.orange : Color.orange.opacity(0.4))
                                 .frame(width: 10, height: 10)
-                            Text(i == 0 ? "Основной" : "Дроп \(i)")
+                            Text(i == 0 ? NSLocalizedString("DropSetView.MainStep", comment: "Основной") : String(format: NSLocalizedString("DropSetView.DropStep", comment: "Дроп %d"), i))
                                 .font(.body)
                                 .foregroundColor( .primary)
                             Spacer()

--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseSetRow.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseSetRow.swift
@@ -18,7 +18,7 @@ struct ExerciseSetRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
-                Text("Сет \(index + 1):")
+                Text(String(format: NSLocalizedString("ExerciseSetRow.SetTitle", comment: "Сет %d:"), index + 1))
                     .font(.caption)
                 Spacer()
                 Toggle("", isOn: $completed)
@@ -44,7 +44,7 @@ struct ExerciseSetRow: View {
             
             // Фактические значения: редактируются всегда
             HStack(spacing: 6) {
-                Text("Факт:")
+                Text(NSLocalizedString("ExerciseSetRow.ActualTitle", comment: "Факт:"))
                     .font(.caption2)
                 ForEach(metrics, id: \.type) { metric in
                     HStack(spacing: 2) {
@@ -72,7 +72,7 @@ struct ExerciseSetRow: View {
             // RPE если нужна (добавь в metrics ExerciseMetric(type: .custom("RPE"), ...))
             if metrics.contains(where: { $0.type == .custom("RPE") }) {
                 HStack {
-                    Text("RPE:")
+                    Text(NSLocalizedString("ExerciseSetRow.RPE", comment: "RPE:"))
                     Slider(value: Binding(
                         get: { actualValues[.custom("RPE")] ?? 5 },
                         set: { actualValues[.custom("RPE")] = $0 }
@@ -83,7 +83,7 @@ struct ExerciseSetRow: View {
             }
 
             // Редактируемые заметки к сету
-            TextField("Заметка к сету", text: $notes)
+            TextField(NSLocalizedString("ExerciseSetRow.NotePlaceholder", comment: "Заметка к сету"), text: $notes)
                 .font(.caption2)
                 .foregroundColor(.yellow)
         }

--- a/FitLink/UIAtoms/WorkoutScreen/SuperSetsApproachView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/SuperSetsApproachView.swift
@@ -14,7 +14,7 @@ struct SupersetApproachView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
-                Text("Подход \(index + 1)")
+                Text(String(format: NSLocalizedString("SupersetApproachView.Title", comment: "Подход %d"), index + 1))
                     .font(.headline)
                     .foregroundColor(Color.blue)
                 Spacer()

--- a/FitLink/UIAtoms/WorkoutSetGroup/WorkoutSetGroupView.swift
+++ b/FitLink/UIAtoms/WorkoutSetGroup/WorkoutSetGroupView.swift
@@ -21,7 +21,7 @@ struct WorkoutSetGroupView: View {
                     .font(.headline.bold())
                     .foregroundColor(viewModel.group.type.color)
                 if let reps = viewModel.group.repeatCount, reps > 1 {
-                    Text("×\(reps)")
+                    Text(String(format: NSLocalizedString("WorkoutSetGroup.RepsMultiplier", comment: "×%d"), reps))
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                         .padding(.leading, 6)
@@ -36,7 +36,7 @@ struct WorkoutSetGroupView: View {
                 if !viewModel.supersetApproaches.isEmpty {
                     SuperSetView(sets: viewModel.supersetApproaches)
                 } else {
-                    Text("Нет подходов в суперсете")
+                    Text(NSLocalizedString("WorkoutSetGroup.EmptySuperset", comment: "Нет подходов в суперсете"))
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
@@ -48,7 +48,7 @@ struct WorkoutSetGroupView: View {
                         approaches: viewModel.dropsetApproaches
                     )
                 } else {
-                    Text("Нет дропсета")
+                    Text(NSLocalizedString("WorkoutSetGroup.EmptyDropset", comment: "Нет дропсета"))
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }

--- a/FitLink/Views/Dashboard/TrainerDashboardView.swift
+++ b/FitLink/Views/Dashboard/TrainerDashboardView.swift
@@ -12,7 +12,7 @@ struct TrainerDashboardView: View {
             VStack(spacing: 16) {
                 // Header
                 HStack {
-                    Text("Привет, Юрий!")
+                    Text(NSLocalizedString("Dashboard.Greeting", comment: "Привет, Юрий!"))
                         .font(.system(size: 22, weight: .bold))
                         .foregroundColor(Color(.label))
                     Spacer()
@@ -44,12 +44,12 @@ struct TrainerDashboardView: View {
                 // Search bar with filter
                 SearchBarWithFilter(
                     text: $viewModel.searchText,
-                    placeholder: "Поиск клиента...",
+                    placeholder: NSLocalizedString("Dashboard.SearchPlaceholder", comment: "Поиск клиента..."),
                     onFilterTapped: { showFilterDialog = true }
                 )
-                .confirmationDialog("Фильтровать по", isPresented: $showFilterDialog, titleVisibility: .visible) {
+                    .confirmationDialog(NSLocalizedString("Dashboard.FilterTitle", comment: "Фильтровать по"), isPresented: $showFilterDialog, titleVisibility: .visible) {
                     ForEach(FilterType.allCases) { filter in
-                        Button(filter.rawValue) {
+                        Button(filter.localized) {
                             selectedFilter = filter
                             viewModel.applyFilter(filter)
                         }
@@ -89,6 +89,17 @@ enum FilterType: String, CaseIterable, Identifiable {
     case nextSessionDate = "По дате следующей тренировки"
     case nextSessionType = "По типу тренировки"
     var id: String { rawValue }
+
+    var localized: String {
+        switch self {
+        case .none:
+            return NSLocalizedString("Dashboard.Filter.None", comment: "Очистить фильтр")
+        case .nextSessionDate:
+            return NSLocalizedString("Dashboard.Filter.NextSessionDate", comment: "По дате следующей тренировки")
+        case .nextSessionType:
+            return NSLocalizedString("Dashboard.Filter.NextSessionType", comment: "По типу тренировки")
+        }
+    }
 }
 
 #Preview {

--- a/FitLink/Views/Dashboard/TrainerDashboardViewModel.swift
+++ b/FitLink/Views/Dashboard/TrainerDashboardViewModel.swift
@@ -43,9 +43,9 @@ final class TrainerDashboardViewModel: ObservableObject {
     // Моки clientStats (оставь если нужны карточки-статистики)
     var clientStats: [StatSummary] {
         [
-            StatSummary(id: "clients", title: "Всего клиентов", value: "\(clients.count)", icon: "person.2", hasDot: false),
-            StatSummary(id: "active", title: "Идёт сейчас", value: "\(currentSessionsCount)", icon: "flame", hasDot: currentSessionsCount > 0),
-            StatSummary(id: "feedback", title: "Отзывов", value: "\(feedbackCount)", icon: "bubble.left", hasDot: false)
+            StatSummary(id: "clients", title: NSLocalizedString("Dashboard.Stats.TotalClients", comment: "Всего клиентов"), value: "\(clients.count)", icon: "person.2", hasDot: false),
+            StatSummary(id: "active", title: NSLocalizedString("Dashboard.Stats.InProgress", comment: "Идёт сейчас"), value: "\(currentSessionsCount)", icon: "flame", hasDot: currentSessionsCount > 0),
+            StatSummary(id: "feedback", title: NSLocalizedString("Dashboard.Stats.Feedback", comment: "Отзывов"), value: "\(feedbackCount)", icon: "bubble.left", hasDot: false)
         ]
     }
     

--- a/FitLink/Views/ExerciseLibrary/ExerciseLibraryView.swift
+++ b/FitLink/Views/ExerciseLibrary/ExerciseLibraryView.swift
@@ -15,7 +15,7 @@ struct ExerciseLibraryView: View {
         NavigationStack {
             VStack(spacing: 12) {
                 HStack {
-                    Text("Упражнения")
+                    Text(NSLocalizedString("ExerciseLibrary.Header", comment: "Упражнения"))
                         .font(.title2.bold())
                     Spacer()
                     Button(action: {
@@ -30,14 +30,14 @@ struct ExerciseLibraryView: View {
 
                 SearchBarWithFilter(
                     text: $viewModel.searchText,
-                    placeholder: "Поиск упражнения...",
+                    placeholder: NSLocalizedString("ExerciseLibrary.SearchPlaceholder", comment: "Поиск упражнения..."),
                     onFilterTapped: {
                         showFilterDialog = true
                     }
                 )
                 .padding(.horizontal)
-                .confirmationDialog("Выберите группу мышц", isPresented: $showFilterDialog) {
-                    Button("Все", role: .none) { viewModel.selectedMuscleGroup = nil }
+                .confirmationDialog(NSLocalizedString("ExerciseLibrary.FilterTitle", comment: "Выберите группу мышц"), isPresented: $showFilterDialog) {
+                    Button(NSLocalizedString("ExerciseLibrary.FilterAll", comment: "Все"), role: .none) { viewModel.selectedMuscleGroup = nil }
                     ForEach(MuscleGroup.allStandardCases, id: \.self) { group in
                         Button(group.displayName) { viewModel.selectedMuscleGroup = group }
                     }

--- a/FitLink/Views/Main/MainView.swift
+++ b/FitLink/Views/Main/MainView.swift
@@ -12,23 +12,23 @@ struct MainView: View {
         TabView {
             TrainerDashboardView()
                 .tabItem {
-                    Label("Dashboard", systemImage: "house")
+                    Label(NSLocalizedString("Main.Tab.Dashboard", comment: "Dashboard"), systemImage: "house")
                 }
             ExerciseLibraryView()
                 .tabItem {
-                    Label("Exercises", systemImage: "list.bullet.rectangle")
+                    Label(NSLocalizedString("Main.Tab.Exercises", comment: "Exercises"), systemImage: "list.bullet.rectangle")
                 }
             ScheduleView()
                 .tabItem {
-                    Label("Schedule", systemImage: "calendar")
+                    Label(NSLocalizedString("Main.Tab.Schedule", comment: "Schedule"), systemImage: "calendar")
                 }
             WorkoutsView()
                 .tabItem {
-                    Label("Workouts", systemImage: "dumbbell")
+                    Label(NSLocalizedString("Main.Tab.Workouts", comment: "Workouts"), systemImage: "dumbbell")
                 }
             ProfileView()
                 .tabItem {
-                    Label("Profile", systemImage: "person.circle")
+                    Label(NSLocalizedString("Main.Tab.Profile", comment: "Profile"), systemImage: "person.circle")
                 }
         }
     }

--- a/FitLink/Views/Schedule/ScheduleView.swift
+++ b/FitLink/Views/Schedule/ScheduleView.swift
@@ -16,7 +16,7 @@ struct ScheduleView: View {
                 // Header с кнопками режимов справа
                 HStack {
                     Spacer()
-                    Text("Занятия")
+                    Text(NSLocalizedString("Schedule.Header", comment: "Занятия"))
                         .font(.title2.bold())
                     Spacer()
                     HStack(spacing: 16) {
@@ -49,7 +49,7 @@ struct ScheduleView: View {
                 // Search
                 SearchBarWithFilter(
                     text: $viewModel.searchText,
-                    placeholder: "Search clients...",
+                    placeholder: NSLocalizedString("Schedule.SearchPlaceholder", comment: "Search clients..."),
                     onFilterTapped: {
                         // Тут future: фильтр по статусу, тренеру и т.д.
                     }

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -20,8 +20,13 @@ struct WorkoutSessionView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
                 // Заголовок
-                Text("Тренировка для \(client?.name ?? "Клиента")")
-                    .font(.title2.bold())
+                Text(
+                    String(
+                        format: NSLocalizedString("WorkoutSession.Header", comment: "Тренировка для %@"),
+                        client?.name ?? NSLocalizedString("WorkoutSession.ClientPlaceholder", comment: "Клиента")
+                    )
+                )
+                .font(.title2.bold())
                 if let date = session.date {
                     Text("\(date.formatted(date: .long, time: .shortened))")
                         .foregroundColor(.secondary)
@@ -51,7 +56,7 @@ struct WorkoutSessionView: View {
             }
             .padding()
         }
-        .navigationTitle("Тренировка")
+        .navigationTitle(NSLocalizedString("WorkoutSession.Title", comment: "Тренировка"))
         .presentationDetents([.medium, .large])
     }
 }


### PR DESCRIPTION
## Summary
- add `Localizable.strings` with keys for UI texts
- replace visible strings in Swift files with `NSLocalizedString` calls
- provide localized variants for enums and helpers

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684067b727b88330ac5cf652050872a3