### PR TITLE
Refactor WorkoutScreen layout

### DIFF
--- a/FitLink/Localization/Localizable.strings
+++ b/FitLink/Localization/Localizable.strings
@@ -131,3 +131,13 @@
 "MuscleGroup.Cardio" = "Кардио";
 "MuscleGroup.Mobility" = "Мобильность";
 "MuscleGroup.FullBody" = "Всё тело";
+\n/* Workout sections */
+"WorkoutSection.WarmUp" = "Разминка";
+"WorkoutSection.Main" = "Основная часть";
+"WorkoutSection.CoolDown" = "Заминка";
+\n/* Workout actions */
+"WorkoutSession.AddExercise" = "Добавить упражнение";
+"WorkoutSession.AddGroupedExercise" = "Добавить групповое упражнение";
+"WorkoutSession.AddBlock" = "Добавить блок";
+"WorkoutSession.ClonePrevious" = "Клонировать прошлую";
+"WorkoutSession.Save" = "Сохранить тренировку";

--- a/FitLink/Localization/Localizable_en.strings
+++ b/FitLink/Localization/Localizable_en.strings
@@ -131,3 +131,13 @@
 "MuscleGroup.Cardio" = "Cardio";
 "MuscleGroup.Mobility" = "Mobility";
 "MuscleGroup.FullBody" = "The whole body";
+\n/* Workout sections */
+"WorkoutSection.WarmUp" = "Warm-up";
+"WorkoutSection.Main" = "Main Set";
+"WorkoutSection.CoolDown" = "Cool-down";
+\n/* Workout actions */
+"WorkoutSession.AddExercise" = "Add Exercise";
+"WorkoutSession.AddGroupedExercise" = "Add Grouped Exercise";
+"WorkoutSession.AddBlock" = "Add Block";
+"WorkoutSession.ClonePrevious" = "Clone Previous Session";
+"WorkoutSession.Save" = "Save Workout";

--- a/FitLink/Models/Workout/ExerciseInstance.swift
+++ b/FitLink/Models/Workout/ExerciseInstance.swift
@@ -13,4 +13,5 @@ struct ExerciseInstance: Identifiable, Codable, Equatable, Hashable {
     var approaches: [Approach]     // Вместо sets!
     var groupId: UUID?
     var notes: String?
+    var section: WorkoutSection = .main
 }

--- a/FitLink/Models/Workout/WorkoutSection.swift
+++ b/FitLink/Models/Workout/WorkoutSection.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Sections of a workout session
+enum WorkoutSection: String, Codable, CaseIterable, Hashable {
+    case warmUp
+    case main
+    case coolDown
+
+    var title: String {
+        switch self {
+        case .warmUp:
+            return NSLocalizedString("WorkoutSection.WarmUp", comment: "Warm-up")
+        case .main:
+            return NSLocalizedString("WorkoutSection.Main", comment: "Main Set")
+        case .coolDown:
+            return NSLocalizedString("WorkoutSection.CoolDown", comment: "Cool-down")
+        }
+    }
+}

--- a/FitLink/Stubs/ComplexSessions+Seeds.swift
+++ b/FitLink/Stubs/ComplexSessions+Seeds.swift
@@ -142,7 +142,7 @@ func makeSupersetApproaches(
 }
 
 // --- ДОБАВЛЯЕМ ОДИНОЧНЫЕ УПРАЖНЕНИЯ ДЛЯ ПРИМЕРА ---
-func makeRegularInstance(exIndex: Int, reps: [Int], weights: [Double]) -> ExerciseInstance {
+func makeRegularInstance(exIndex: Int, reps: [Int], weights: [Double], section: WorkoutSection = .main) -> ExerciseInstance {
     let ex = exercisesCatalog[exIndex]
     let approaches = zip(reps, weights).map { (rep, weight) in
         Approach(
@@ -159,7 +159,8 @@ func makeRegularInstance(exIndex: Int, reps: [Int], weights: [Double]) -> Exerci
         exercise: ex,
         approaches: approaches,
         groupId: nil,
-        notes: nil
+        notes: nil,
+        section: section
     )
 }
 

--- a/FitLink/Stubs/SetsGenerator.swift
+++ b/FitLink/Stubs/SetsGenerator.swift
@@ -36,12 +36,13 @@ func generateRegularApproaches(for exercise: Exercise, count: Int) -> [Approach]
 }
 
 
-func makeInstance(exercise: Exercise, approachesCount: Int = 3) -> ExerciseInstance {
+func makeInstance(exercise: Exercise, approachesCount: Int = 3, section: WorkoutSection = .main) -> ExerciseInstance {
     ExerciseInstance(
         id: UUID(),
         exercise: exercise,
         approaches: generateRegularApproaches(for: exercise, count: approachesCount),
         groupId: nil,
-        notes: nil
+        notes: nil,
+        section: section
     )
 }

--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
@@ -1,169 +1,60 @@
-//
-//  ExerciseBlockCard.swift
-//  FitLink
-//
-//  Created by Дмитрий Гришечко on 31.05.2025.
-//
 import SwiftUI
 
-/// Универсальная карточка упражнения/группы для экрана тренировки
+/// Flat card representing either a single exercise or a grouped block
 struct ExerciseBlockCard: View {
     let group: SetGroup?
     let exerciseInstances: [ExerciseInstance]
-    @State private var isExpanded: Bool = false
 
     var body: some View {
-        VStack(spacing: 0) {
-            // Header (compact)
-            HStack(spacing: 8) {
-                if let group = group {
-                    VStack(alignment: .leading, spacing: 2) {
-                        HStack(spacing: 8) {
-                            VariationTypeBadge(text: group.type.displayName, color: group.type.color)
-                        }
-                        // Названия упражнений — всегда с новой строки
-                        if group.type == .superset {
-                            ForEach(exerciseInstances, id: \.id) { ex in
-                                Text(ex.exercise.name)
-                                    .font(.headline)
-                                    .foregroundColor(.primary)
-                                    .padding(.vertical, 1)
-                            }
-                        } else if let first = exerciseInstances.first {
-                            Text(first.exercise.name)
-                                .font(.headline)
-                                .foregroundColor(.primary)
-                        }
-                    }
-                } else if let exercise = exerciseInstances.first {
-                    Text(exercise.exercise.name)
-                        .font(.headline)
-                        .foregroundColor(.primary)
-                }
-                Spacer()
-                Text("×\(setCount)")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                    .foregroundColor(.secondary)
+        VStack(alignment: .leading, spacing: Theme.spacing.small) {
+            if let group {
+                Text(group.type.displayName)
+                    .font(Theme.font.caption)
+                    .foregroundColor(Theme.color.textSecondary)
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 16)
-            .contentShape(Rectangle())
-            .onTapGesture { withAnimation { isExpanded.toggle() } }
 
-            if isExpanded {
-                Divider()
-                VStack(alignment: .leading, spacing: 0) {
-                    expandedContent
+            Text(title)
+                .font(Theme.font.subheading)
+                .lineLimit(2)
+                .truncationMode(.tail)
+
+            Text(summary)
+                .font(Theme.font.metadata)
+                .foregroundColor(Theme.color.textSecondary)
+        }
+        .padding(Theme.spacing.medium)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.color.backgroundSecondary)
+        .cornerRadius(Theme.radius.card)
+    }
+
+    private var title: String {
+        let names = exerciseInstances.map { $0.exercise.name }
+        if let group, group.type == .superset {
+            return names.joined(separator: " + ")
+        }
+        return names.joined(separator: " \u{2022} ")
+    }
+
+    private var summary: String {
+        guard let first = exerciseInstances.first else {
+            return "\(setCount) sets"
+        }
+        var parts: [String] = ["\(setCount) sets"]
+        if let approach = first.approaches.first {
+            for metric in first.exercise.metrics {
+                if let value = approach.set.metricValues[metric.type] {
+                    parts.append(ExerciseMetric.formattedMetric(value, metric: metric))
                 }
-                //.padding(16) // внутренний отступ для контента
             }
         }
-        .background(
-            RoundedRectangle(cornerRadius: 16)
-                .fill(backgroundColor)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 16)
-                        .stroke(borderColor, lineWidth: 0.3)
-                )
-        )
-        .padding(.horizontal, 0)
-        //.padding(.vertical, )
+        return parts.joined(separator: " \u{00b7} ")
     }
 
     private var setCount: Int {
-        if group != nil {
-            // Для групп считаем максимальное число подходов среди всех упражнений
+        if let group {
             return exerciseInstances.map { $0.approaches.count }.max() ?? 0
-        } else if let exercise = exerciseInstances.first {
-            return exercise.approaches.count
         }
-        return 0
-    }
-
-    private var backgroundColor: Color {
-        group?.type.color.opacity(0.07) ?? Color(.secondarySystemBackground)
-    }
-    private var borderColor: Color {
-        group?.type.color ?? .gray
-    }
-
-    @ViewBuilder
-    private var expandedContent: some View {
-        if let group = group {
-            switch group.type {
-            case .dropset:
-                ForEach(exerciseInstances) { ex in
-                    DropSetView(exercise: ex, approaches: ex.approaches.map { DropSetApproach(steps: [$0.set] + $0.drops) })
-                }
-            case .superset:
-                SuperSetView(sets: supersetApproaches)
-            default:
-                // future: circuit, pyramid, etc.
-                EmptyView()
-            }
-        } else if let exercise = exerciseInstances.first {
-            ExerciseApproachListView(exerciseInstance: exercise)
-                .padding()
-        }
-    }
-
-    // Собираем данные для SuperSetView
-    private var supersetApproaches: [SupersetApproach] {
-        // Собираем подходы суперсета в табличный вид:
-        // Для каждого индекса подхода собираем ExerciseResult для каждого упражнения
-        guard !exerciseInstances.isEmpty else { return [] }
-        let maxApproaches = exerciseInstances.map { $0.approaches.count }.max() ?? 0
-        var result: [SupersetApproach] = []
-        for setIndex in 0..<maxApproaches {
-            var exerciseResults: [ExerciseResult] = []
-            for ex in exerciseInstances {
-                if ex.approaches.indices.contains(setIndex) {
-                    let approach = ex.approaches[setIndex]
-                    let metrics = ex.exercise.metrics
-                    let metricValues: [MetricValue] = metrics.compactMap { metric in
-                        if let value = approach.set.metricValues[metric.type] {
-                            return MetricValue(type: metric.type, displayName: metric.type.displayName, value: ExerciseMetric.formattedMetric(value, metric: metric), iconName: metric.iconName)
-                        } else {
-                            return nil
-                        }
-                    }
-                    exerciseResults.append(ExerciseResult(exerciseName: ex.exercise.name, metricValues: metricValues))
-                } else {
-                    // Если подхода нет, добавляем пустой
-                    exerciseResults.append(ExerciseResult(exerciseName: ex.exercise.name, metricValues: []))
-                }
-            }
-            result.append(SupersetApproach(exercises: exerciseResults))
-        }
-        return result
+        return exerciseInstances.first?.approaches.count ?? 0
     }
 }
-
-#if DEBUG
-struct WorkoutExerciseCard_Previews: PreviewProvider {
-    static var previews: some View {
-        VStack(spacing: 16) {
-            // Обычное упражнение
-            let metrics = [ExerciseMetric(type: .reps, isRequired: true), ExerciseMetric(type: .weight, isRequired: false)]
-            let set = ExerciseSet(id: UUID(), metricValues: [.reps: 10, .weight: 50], notes: nil, drops: nil)
-            let approach = Approach(set: set, drops: [])
-            let exercise = ExerciseInstance(id: UUID(), exercise: Exercise(id: UUID(), name: "Становая тяга", description: "", mediaURL: nil, variations: [], muscleGroups: [], metrics: metrics), approaches: [approach, approach, approach], groupId: nil, notes: nil)
-            ExerciseBlockCard(group: nil, exerciseInstances: [exercise])
-
-            // Дропсет
-            let dropSetGroup = SetGroup(id: UUID(), type: .dropset, exerciseInstanceIds: [exercise.id], repeatCount: 2)
-            ExerciseBlockCard(group: dropSetGroup, exerciseInstances: [exercise])
-
-            // Суперсет
-            let ex1 = ExerciseInstance(id: UUID(), exercise: Exercise(id: UUID(), name: "Сгибания рук", description: "", mediaURL: nil, variations: [], muscleGroups: [], metrics: metrics), approaches: [approach, approach, approach], groupId: nil, notes: nil)
-            let ex2 = ExerciseInstance(id: UUID(), exercise: Exercise(id: UUID(), name: "Тяга штанги", description: "", mediaURL: nil, variations: [], muscleGroups: [], metrics: metrics), approaches: [approach, approach, approach], groupId: nil, notes: nil)
-            let superSetGroup = SetGroup(id: UUID(), type: .superset, exerciseInstanceIds: [ex1.id, ex2.id], repeatCount: 3)
-            ExerciseBlockCard(group: superSetGroup, exerciseInstances: [ex1, ex2])
-        }
-        .padding()
-        .previewLayout(.sizeThatFits)
-    }
-}
-#endif

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -9,16 +9,22 @@ import SwiftUI
 struct WorkoutSessionView: View {
     let session: WorkoutSession
     let client: Client?
-    
-    // 1. Вынеси фильтрацию в отдельную переменную (читабельность)
-    var singleExercises: [ExerciseInstance] {
-        let groupedIds = Set((session.setGroups ?? []).flatMap { $0.exerciseInstanceIds })
-        return session.exerciseInstances.filter { !groupedIds.contains($0.id) }
+
+    private var warmUpExercises: [ExerciseInstance] {
+        session.exerciseInstances.filter { $0.section == .warmUp }
+    }
+
+    private var mainExercises: [ExerciseInstance] {
+        session.exerciseInstances.filter { $0.section == .main }
+    }
+
+    private var coolDownExercises: [ExerciseInstance] {
+        session.exerciseInstances.filter { $0.section == .coolDown }
     }
     
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: Theme.spacing.large) {
                 // Заголовок
                 Text(
                     String(
@@ -37,27 +43,44 @@ struct WorkoutSessionView: View {
                         .foregroundColor(Theme.color.accent)
                         .padding(.vertical, Theme.spacing.small / 2)
                 }
-                
-                // --- Универсальный список упражнений и групп ---
-                ForEach(session.exerciseInstances) { exerciseInstance in
-                    // Проверяем, входит ли упражнение в какую-либо группу
-                    if let group = (session.setGroups?.first { $0.exerciseInstanceIds.contains(exerciseInstance.id) }) {
-                        // Если это первое упражнение группы — рендерим карточку группы
-                        if group.exerciseInstanceIds.first == exerciseInstance.id {
-                            let groupExercises = session.exerciseInstances.filter { group.exerciseInstanceIds.contains($0.id) }
-                            ExerciseBlockCard(group: group, exerciseInstances: groupExercises)
-                        }
-                        // Остальные упражнения группы не рендерим отдельно
-                    } else {
-                        // Одиночное упражнение
-                        ExerciseBlockCard(group: nil, exerciseInstances: [exerciseInstance])
-                    }
+
+                workoutSectionView(title: WorkoutSection.warmUp.title, exercises: warmUpExercises)
+                workoutSectionView(title: WorkoutSection.main.title, exercises: mainExercises)
+                workoutSectionView(title: WorkoutSection.coolDown.title, exercises: coolDownExercises)
+
+                VStack(spacing: Theme.spacing.medium) {
+                    Button(NSLocalizedString("WorkoutSession.AddGroupedExercise", comment: "")) {}
+                    Button(NSLocalizedString("WorkoutSession.AddBlock", comment: "")) {}
+                    Button(NSLocalizedString("WorkoutSession.ClonePrevious", comment: "")) {}
+                    Button(NSLocalizedString("WorkoutSession.Save", comment: "")) {}
                 }
             }
             .padding(Theme.spacing.medium)
         }
         .navigationTitle(NSLocalizedString("WorkoutSession.Title", comment: "Тренировка"))
         .presentationDetents([.medium, .large])
+    }
+
+    @ViewBuilder
+    private func workoutSectionView(title: String, exercises: [ExerciseInstance]) -> some View {
+        VStack(alignment: .leading, spacing: Theme.spacing.small) {
+            Text(title)
+                .font(Theme.font.subheading).bold()
+
+            ForEach(exercises) { ex in
+                if let group = session.setGroups?.first(where: { $0.exerciseInstanceIds.contains(ex.id) }),
+                   group.exerciseInstanceIds.first == ex.id {
+                    let groupExercises = session.exerciseInstances.filter { group.exerciseInstanceIds.contains($0.id) }
+                    ExerciseBlockCard(group: group, exerciseInstances: groupExercises)
+                } else if !(session.setGroups ?? []).contains(where: { $0.exerciseInstanceIds.contains(ex.id) }) {
+                    ExerciseBlockCard(group: nil, exerciseInstances: [ex])
+                }
+            }
+
+            Button(NSLocalizedString("WorkoutSession.AddExercise", comment: "")) {}
+                .font(Theme.font.body)
+                .foregroundColor(Theme.color.accent)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add `WorkoutSection` enum and reference from `ExerciseInstance`
- simplify `ExerciseBlockCard` design
- update `WorkoutSessionView` to show warm-up, main, cool-down sections
- localize workout sections and new actions

## Testing
- `swiftc -parse FitLink/Models/Workout/WorkoutSection.swift`
- `swiftc -parse FitLink/Models/Workout/ExerciseInstance.swift`
- `swiftc -parse FitLink/Stubs/SetsGenerator.swift`
- `swiftc -parse FitLink/Stubs/ComplexSessions+Seeds.swift`
- `swiftc -parse FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift`
- `swiftc -parse FitLink/Views/WorkoutSession/WorkoutSessionView.swift`


------
https://chatgpt.com/codex/tasks/task_e_68430386ce688330aa0dc18f02b1c18f