### PR TITLE
Refactor WorkoutSession UI

### DIFF
--- a/FitLink/UIAtoms/PrimaryButton.swift
+++ b/FitLink/UIAtoms/PrimaryButton.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// Full-width primary action button
+struct PrimaryButton: View {
+    let title: String
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(Theme.font.titleSmall)
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, Theme.spacing.medium)
+                .background(Theme.color.accent)
+                .cornerRadius(Theme.radius.button)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    PrimaryButton(title: NSLocalizedString("WorkoutSession.AddExercise", comment: "")) {}
+        .padding()
+        .previewLayout(.sizeThatFits)
+}

--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
@@ -38,9 +38,9 @@ struct ExerciseBlockCard: View {
 
     private var summary: String {
         guard let first = exerciseInstances.first else {
-            return "\(setCount) sets"
+            return "\(setCount) \(setsText)"
         }
-        var parts: [String] = ["\(setCount) sets"]
+        var parts: [String] = ["\(setCount) \(setsText)"]
         if let approach = first.approaches.first {
             for metric in first.exercise.metrics {
                 if let value = approach.set.metricValues[metric.type] {
@@ -49,6 +49,16 @@ struct ExerciseBlockCard: View {
             }
         }
         return parts.joined(separator: " \u{00b7} ")
+    }
+
+    private var setsText: String {
+        let mod100 = setCount % 100
+        if mod100 >= 11 && mod100 <= 14 { return "подходов" }
+        switch setCount % 10 {
+        case 1: return "подход"
+        case 2,3,4: return "подхода"
+        default: return "подходов"
+        }
     }
 
     private var setCount: Int {

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -48,15 +48,8 @@ struct WorkoutSessionView: View {
                 workoutSectionView(title: WorkoutSection.main.displayName, exercises: mainExercises)
                 workoutSectionView(title: WorkoutSection.coolDown.displayName, exercises: coolDownExercises)
 
-                VStack(spacing: Theme.spacing.medium) {
-                    WorkoutActionButton(label: WorkoutSessionAction.addGroupedExercise.label) {}
-                    WorkoutActionButton(label: WorkoutSessionAction.addBlock.label) {}
-                    WorkoutActionButton(label: WorkoutSessionAction.clonePrevious.label) {}
-                    WorkoutActionButton(label: WorkoutSessionAction.save.label, filled: true) {}
-                        .padding(Theme.spacing.medium)
-                }
-                .multilineTextAlignment(.center)
-                .padding(.top, Theme.spacing.medium)
+                PrimaryButton(title: WorkoutSessionAction.addExercise.label) {}
+                    .padding(.top, Theme.spacing.extraLarge)
             }
             .padding(Theme.spacing.medium)
         }
@@ -80,9 +73,6 @@ struct WorkoutSessionView: View {
                     }
                 }
             }
-
-            WorkoutActionButton(label: WorkoutSessionAction.addExercise.label) {}
-                .padding(.top, Theme.spacing.medium)
         }
         .padding(.bottom, Theme.spacing.large)
     }


### PR DESCRIPTION
## Summary
- add reusable **PrimaryButton** component for accent actions
- use `PrimaryButton` at bottom of `WorkoutSessionView`
- remove outdated action buttons and per-section add button
- format exercise summary in Russian

## Testing
- `swiftc -dump-parse FitLink/UIAtoms/PrimaryButton.swift`
- `swiftc -dump-parse FitLink/Views/WorkoutSession/WorkoutSessionView.swift`


------
https://chatgpt.com/codex/tasks/task_e_684314cdf7408330948aeb7e93453563