### PR TITLE
Fix WorkoutScreen labels

### DIFF
--- a/FitLink/Models/Workout/WorkoutSection.swift
+++ b/FitLink/Models/Workout/WorkoutSection.swift
@@ -18,6 +18,18 @@ enum WorkoutSection: String, Codable, CaseIterable, Hashable {
         }
     }
 
+    /// Display title used in UI labels
+    var displayTitle: String {
+        switch self {
+        case .warmUp:
+            return NSLocalizedString("WorkoutSection.WarmUp", comment: "Разминка")
+        case .main:
+            return NSLocalizedString("WorkoutSection.Main", comment: "Основная часть")
+        case .coolDown:
+            return NSLocalizedString("WorkoutSection.CoolDown", comment: "Заминка")
+        }
+    }
+
     @available(*, deprecated, renamed: "displayName")
     var title: String { displayName }
 }

--- a/FitLink/Models/Workout/WorkoutSessionAction.swift
+++ b/FitLink/Models/Workout/WorkoutSessionAction.swift
@@ -12,4 +12,7 @@ enum WorkoutSessionAction: String, CaseIterable, Hashable {
     var label: String {
         NSLocalizedString(rawValue, comment: "")
     }
+
+    /// Title used for action buttons
+    var buttonTitle: String { label }
 }

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -44,11 +44,11 @@ struct WorkoutSessionView: View {
                         .padding(.vertical, Theme.spacing.small / 2)
                 }
 
-                workoutSectionView(title: WorkoutSection.warmUp.displayName, exercises: warmUpExercises)
-                workoutSectionView(title: WorkoutSection.main.displayName, exercises: mainExercises)
-                workoutSectionView(title: WorkoutSection.coolDown.displayName, exercises: coolDownExercises)
+                workoutSectionView(title: WorkoutSection.warmUp.displayTitle, exercises: warmUpExercises)
+                workoutSectionView(title: WorkoutSection.main.displayTitle, exercises: mainExercises)
+                workoutSectionView(title: WorkoutSection.coolDown.displayTitle, exercises: coolDownExercises)
 
-                PrimaryButton(title: NSLocalizedString("WorkoutSession.AddExercise", comment: "")) {}
+                PrimaryButton(title: WorkoutSessionAction.addExercise.buttonTitle) {}
                     .padding(.top, Theme.spacing.extraLarge)
             }
             .padding(Theme.spacing.medium)


### PR DESCRIPTION
## Summary
- show localized section titles via `WorkoutSection.displayTitle`
- expose `buttonTitle` for WorkoutSession actions
- use the new properties in `WorkoutSessionView`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68431a6af8588330a760bd33ae064f8e