### PR TITLE
Fix dropsets display by merging drops into sets

### DIFF
--- a/FitLink/Models/Workout/Approach.swift
+++ b/FitLink/Models/Workout/Approach.swift
@@ -10,4 +10,13 @@ struct Approach: Identifiable, Codable, Equatable, Hashable {
     var id: UUID = UUID()
     var set: ExerciseSet
     var drops: [ExerciseSet] // Пустой если нет дропов
+
+    /// Convenience accessor that merges `set` with its `drops` array.
+    /// This allows views that operate on `ExerciseSet` to access dropsets
+    /// without needing to know about the `Approach` container.
+    var setWithDrops: ExerciseSet {
+        var copy = set
+        copy.drops = drops
+        return copy
+    }
 }

--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseApproachListView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseApproachListView.swift
@@ -27,7 +27,7 @@ struct ExerciseApproachListView: View {
             )
         } else {
             ApproachSetView(
-                set: approach.set,
+                set: approach.setWithDrops,
                 index: index,
                 metrics: exerciseInstance.exercise.metrics
             )

--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
@@ -20,7 +20,7 @@ struct ExerciseBlockCard: View {
 
             if let main = exerciseInstances.first {
                 ExerciseSetMetricsView(
-                    sets: main.approaches.map { $0.set },
+                    sets: main.approaches.map { $0.setWithDrops },
                     metrics: main.exercise.metrics
                 )
             }


### PR DESCRIPTION
## Summary
- add `setWithDrops` computed property on Approach to merge dropsets
- use merged sets when rendering exercise block cards and approach list

## Testing
- `swiftc --version`
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project FitLink.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eea09c9608330886d168d5d0d69b6