### PR TITLE
Add expandable superset view

### DIFF
--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -90,7 +90,11 @@ struct WorkoutSessionView: View {
                         if let group = session.setGroups?.first(where: { $0.exerciseInstanceIds.contains(ex.id) }),
                            group.exerciseInstanceIds.first == ex.id {
                             let groupExercises = session.exerciseInstances.filter { group.exerciseInstanceIds.contains($0.id) }
-                            ExerciseBlockCard(group: group, exerciseInstances: groupExercises)
+                            if group.type == .superset {
+                                SupersetCell(group: group, exercises: groupExercises)
+                            } else {
+                                ExerciseBlockCard(group: group, exerciseInstances: groupExercises)
+                            }
                         } else if !(session.setGroups ?? []).contains(where: { $0.exerciseInstanceIds.contains(ex.id) }) {
                             ExerciseBlockCard(group: nil, exerciseInstances: [ex])
                         }


### PR DESCRIPTION
## Summary
- add `SupersetCell` with collapsible approaches
- use `SupersetCell` in workout session view when showing supersets

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684f46ec48fc833094ae1d280d663440