### PR TITLE
Improve superset approach layout

### DIFF
--- a/FitLink/UIAtoms/WorkoutScreen/SupersetApproachView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/SupersetApproachView.swift
@@ -14,8 +14,13 @@ struct SupersetApproachView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.spacing.small) {
             Text(String(format: NSLocalizedString("SupersetApproachView.Title", comment: "Approach %d"), index))
-                .font(Theme.font.body.bold())
-            ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                .font(Theme.font.subheading.bold())
+                .foregroundColor(Theme.color.accent)
+            ForEach(Array(items.enumerated()), id: \.offset) { idx, item in
+                if idx > 0 {
+                    Divider()
+                        .background(Theme.color.border.opacity(0.3))
+                }
                 VStack(alignment: .leading, spacing: Theme.spacing.small / 2) {
                     Text(item.exercise.exercise.name)
                         .font(Theme.font.body).bold()

--- a/FitLink/UIAtoms/WorkoutScreen/SupersetCell.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/SupersetCell.swift
@@ -28,11 +28,12 @@ struct SupersetCell: View {
         VStack(alignment: .leading, spacing: Theme.spacing.small) {
             header
             if isExpanded {
-                VStack(alignment: .leading, spacing: Theme.spacing.medium) {
+                VStack(alignment: .leading, spacing: Theme.spacing.small * 1.5) {
                     ForEach(Array(approaches.enumerated()), id: \.offset) { idx, data in
                         SupersetApproachView(index: idx + 1, items: data)
                         if idx < approaches.count - 1 {
                             Divider()
+                                .background(Theme.color.border.opacity(0.5))
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- adjust spacing between superset approaches for better separation
- highlight approach headers using accent color
- add light dividers for clarity

## Testing
- `swift build -c release` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684fe21f5878833082a243b86caf3c13