### PR TITLE
Refactor ExerciseSetMetricsView responsive scrolling

### DIFF
--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseSetMetricsView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseSetMetricsView.swift
@@ -57,32 +57,33 @@ struct ExerciseSetMetricsView: View {
         }
     }
 
+    /// Invisible view used to measure the intrinsic width of the metrics stack.
+    private var widthMeasurer: some View {
+        metricsContent()
+            .fixedSize()
+            .background(
+                GeometryReader { proxy in
+                    Color.clear.preference(key: WidthKey.self, value: proxy.size.width)
+                }
+            )
+    }
+
     var body: some View {
         GeometryReader { geo in
-            VStack {
+            VStack(alignment: .leading) {
                 Divider()
                     .padding(.vertical, 4)
-                Group {
-                    if contentWidth > geo.size.width {
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            metricsContent()
-                        }
-                    } else {
+                if contentWidth > geo.size.width {
+                    ScrollView(.horizontal, showsIndicators: false) {
                         metricsContent()
                     }
-                }
-                .overlay(
+                } else {
                     metricsContent()
-                        .fixedSize()
-                        .background(
-                            GeometryReader { proxy in
-                                Color.clear.preference(key: WidthKey.self, value: proxy.size.width)
-                            }
-                        )
-                        .hidden()
-                )
-                .onPreferenceChange(WidthKey.self) { contentWidth = $0 }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
             }
+            .background(widthMeasurer.hidden())
+            .onPreferenceChange(WidthKey.self) { contentWidth = $0 }
         }
     }
     

--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseSetMetricsView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseSetMetricsView.swift
@@ -67,7 +67,7 @@ struct ExerciseSetMetricsView: View {
         }
     }
 
-    /// Metrics content wrapped with a background geometry reader to measure width.
+    /// Invisible copy of the metrics used solely for width measurement.
     private var measuredContent: some View {
         metricsContent()
             .fixedSize()
@@ -91,12 +91,13 @@ struct ExerciseSetMetricsView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             GeometryReader { geo in
                 Color.clear.preference(key: ContainerWidthKey.self, value: geo.size.width)
             }
         )
-        .background(measuredContent.opacity(0))
+        .overlay(measuredContent.opacity(0))
         .onPreferenceChange(WidthKey.self) { contentWidth = $0 }
         .onPreferenceChange(ContainerWidthKey.self) { containerWidth = $0 }
     }

--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseSetMetricsView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseSetMetricsView.swift
@@ -5,18 +5,8 @@ struct ExerciseSetMetricsView: View {
     let sets: [ExerciseSet]
     let metrics: [ExerciseMetric]
 
-    /// Width of the container available for metrics.
-    @State private var containerWidth: CGFloat = 0
     /// Tracks the width required to display all sets without scrolling.
     @State private var contentWidth: CGFloat = 0
-
-    /// Preference key for capturing the container width.
-    private struct ContainerWidthKey: PreferenceKey {
-        static var defaultValue: CGFloat = 0
-        static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-            value = nextValue()
-        }
-    }
 
     /// Preference key used to pass width measurements up the view tree.
     private struct WidthKey: PreferenceKey {
@@ -79,27 +69,23 @@ struct ExerciseSetMetricsView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading) {
-            Divider()
-                .padding(.vertical, 4)
-            if contentWidth > containerWidth {
-                ScrollView(.horizontal, showsIndicators: false) {
+        GeometryReader { geo in
+            VStack(alignment: .leading) {
+                Divider()
+                    .padding(.vertical, 4)
+                if contentWidth > geo.size.width {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        metricsContent()
+                    }
+                } else {
                     metricsContent()
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
-            } else {
-                metricsContent()
-                    .frame(maxWidth: .infinity, alignment: .leading)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .overlay(measuredContent.hidden())
+            .onPreferenceChange(WidthKey.self) { contentWidth = $0 }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            GeometryReader { geo in
-                Color.clear.preference(key: ContainerWidthKey.self, value: geo.size.width)
-            }
-        )
-        .overlay(measuredContent.opacity(0))
-        .onPreferenceChange(WidthKey.self) { contentWidth = $0 }
-        .onPreferenceChange(ContainerWidthKey.self) { containerWidth = $0 }
     }
     
     private func weightString(for set: ExerciseSet) -> String {

--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseSetMetricsView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseSetMetricsView.swift
@@ -57,10 +57,9 @@ struct ExerciseSetMetricsView: View {
         }
     }
 
-    /// Invisible view used to measure the intrinsic width of the metrics stack.
-    private var widthMeasurer: some View {
+    /// Metrics content wrapped with a background geometry reader to measure width.
+    private var measuredContent: some View {
         metricsContent()
-            .fixedSize()
             .background(
                 GeometryReader { proxy in
                     Color.clear.preference(key: WidthKey.self, value: proxy.size.width)
@@ -82,7 +81,7 @@ struct ExerciseSetMetricsView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
-            .background(widthMeasurer.hidden())
+            .background(measuredContent.opacity(0))
             .onPreferenceChange(WidthKey.self) { contentWidth = $0 }
         }
     }


### PR DESCRIPTION
## Summary
- measure ExerciseSetMetricsView content width with a hidden overlay
- only enable horizontal ScrollView when needed to display sets

## Testing
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_e_684ff95ce71c83308554005c4536858c