### PR TITLE
Refactor WorkoutSessionView to use dedicated row

### DIFF
--- a/FitLink/Localization/en.lproj/Localizable.strings
+++ b/FitLink/Localization/en.lproj/Localizable.strings
@@ -161,3 +161,4 @@
 /* Common */
 "Common.Cancel" = "Cancel";
 "Common.Done" = "Done";
+"Common.Delete" = "Delete";

--- a/FitLink/Localization/ru.lproj/Localizable.strings
+++ b/FitLink/Localization/ru.lproj/Localizable.strings
@@ -161,3 +161,4 @@
 /* Common */
 "Common.Cancel" = "Отмена";
 "Common.Done" = "Готово";
+"Common.Delete" = "Удалить";

--- a/FitLink/Views/WorkoutSession/WorkoutExerciseRowView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutExerciseRowView.swift
@@ -44,10 +44,7 @@ struct WorkoutExerciseRowView: View {
                 }
             }
             .buttonStyle(.plain)
-            .swipeActions {
-                deleteButton
-            }
-
+            
             if isExpanded {
                 VStack(alignment: .leading, spacing: Theme.spacing.small * 1.5) {
                     ForEach(Array(supersetApproaches.enumerated()), id: \.offset) { idx, data in
@@ -67,6 +64,10 @@ struct WorkoutExerciseRowView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Theme.color.backgroundSecondary)
         .cornerRadius(Theme.radius.card)
+        .contentShape(Rectangle())
+        .swipeActions {
+            deleteButton
+        }
     }
 
     private var simpleRow: some View {
@@ -81,9 +82,6 @@ struct WorkoutExerciseRowView: View {
                 .font(Theme.font.subheading)
                 .lineLimit(2)
                 .truncationMode(.tail)
-                .swipeActions {
-                    deleteButton
-                }
 
             let main = groupExercises.first ?? exercise
             ExerciseSetMetricsView(
@@ -99,6 +97,10 @@ struct WorkoutExerciseRowView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Theme.color.backgroundSecondary)
         .cornerRadius(Theme.radius.card)
+        .contentShape(Rectangle())
+        .swipeActions {
+            deleteButton
+        }
     }
 
     private var deleteButton: some View {

--- a/FitLink/Views/WorkoutSession/WorkoutExerciseRowView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutExerciseRowView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+/// Reusable row for a workout exercise or set group
+struct WorkoutExerciseRowView: View {
+    let exercise: ExerciseInstance
+    let group: SetGroup?
+    let groupExercises: [ExerciseInstance]
+
+    init(exercise: ExerciseInstance, group: SetGroup? = nil, groupExercises: [ExerciseInstance] = []) {
+        self.exercise = exercise
+        self.group = group
+        self.groupExercises = groupExercises
+    }
+
+    var body: some View {
+        Group {
+            if let group {
+                if group.type == .superset {
+                    SupersetCell(group: group, exercises: groupExercises)
+                } else {
+                    ExerciseBlockCard(group: group, exerciseInstances: groupExercises)
+                }
+            } else {
+                ExerciseBlockCard(group: nil, exerciseInstances: [exercise])
+            }
+        } //: Group
+    }
+}
+
+@MainActor
+final class WorkoutExerciseRowViewModel: ObservableObject {}
+
+#Preview {
+    if let session = MockData.complexMockSessions.first {
+        WorkoutExerciseRowView(
+            exercise: session.exerciseInstances.first!,
+            group: session.setGroups?.first,
+            groupExercises: session.setGroups?.first.map { grp in session.exerciseInstances.filter { grp.exerciseInstanceIds.contains($0.id) } } ?? []
+        )
+        .padding()
+    }
+}

--- a/FitLink/Views/WorkoutSession/WorkoutExerciseRowView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutExerciseRowView.swift
@@ -5,25 +5,128 @@ struct WorkoutExerciseRowView: View {
     let exercise: ExerciseInstance
     let group: SetGroup?
     let groupExercises: [ExerciseInstance]
+    let onDelete: () -> Void
 
-    init(exercise: ExerciseInstance, group: SetGroup? = nil, groupExercises: [ExerciseInstance] = []) {
-        self.exercise = exercise
-        self.group = group
-        self.groupExercises = groupExercises
-    }
+    @State private var isExpanded = false
 
     var body: some View {
         Group {
-            if let group {
-                if group.type == .superset {
-                    SupersetCell(group: group, exercises: groupExercises)
-                } else {
-                    ExerciseBlockCard(group: group, exerciseInstances: groupExercises)
-                }
+            if let group, group.type == .superset {
+                supersetRow
             } else {
-                ExerciseBlockCard(group: nil, exerciseInstances: [exercise])
+                simpleRow
             }
         } //: Group
+    }
+
+    private var supersetRow: some View {
+        VStack(alignment: .leading, spacing: Theme.spacing.small) {
+            Button(action: { withAnimation { isExpanded.toggle() } }) {
+                HStack(alignment: .center) {
+                    VStack(alignment: .leading, spacing: Theme.spacing.small / 2) {
+                        Text(group?.type.displayName ?? "")
+                            .font(Theme.font.caption)
+                            .foregroundColor(Theme.color.textSecondary)
+                        Text(supersetTitle)
+                            .font(Theme.font.subheading)
+                            .lineLimit(2)
+                            .truncationMode(.tail)
+                        if !isExpanded, let summary = supersetSummary {
+                            Text(summary)
+                                .font(Theme.font.metadata)
+                                .foregroundColor(Theme.color.textSecondary)
+                        }
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.down")
+                        .rotationEffect(.degrees(isExpanded ? 180 : 0))
+                        .foregroundColor(.secondary)
+                }
+            }
+            .buttonStyle(.plain)
+            .swipeActions {
+                deleteButton
+            }
+
+            if isExpanded {
+                VStack(alignment: .leading, spacing: Theme.spacing.small * 1.5) {
+                    ForEach(Array(supersetApproaches.enumerated()), id: \.offset) { idx, data in
+                        SupersetApproachView(index: idx + 1, items: data)
+                            .padding(Theme.spacing.small)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                    .fill(Theme.color.supersetSubcardBackground)
+                            )
+                    }
+                }
+                .padding(.top, Theme.spacing.small)
+            }
+        }
+        .padding(Theme.spacing.medium)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.color.backgroundSecondary)
+        .cornerRadius(Theme.radius.card)
+    }
+
+    private var simpleRow: some View {
+        VStack(alignment: .leading, spacing: Theme.spacing.small) {
+            if let group, group.type != .superset {
+                Text(group.type.displayName)
+                    .font(Theme.font.caption)
+                    .foregroundColor(Theme.color.textSecondary)
+            }
+
+            Text(simpleTitle)
+                .font(Theme.font.subheading)
+                .lineLimit(2)
+                .truncationMode(.tail)
+                .swipeActions {
+                    deleteButton
+                }
+
+            let main = groupExercises.first ?? exercise
+            ExerciseSetMetricsView(
+                sets: main.approaches.map { approach in
+                    var first = approach.sets.first ?? ExerciseSet(id: UUID(), metricValues: [:], notes: nil, drops: nil)
+                    first.drops = Array(approach.sets.dropFirst())
+                    return first
+                },
+                metrics: main.exercise.metrics
+            )
+        }
+        .padding(Theme.spacing.medium)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.color.backgroundSecondary)
+        .cornerRadius(Theme.radius.card)
+    }
+
+    private var deleteButton: some View {
+        Button(role: .destructive, action: onDelete) {
+            Label(NSLocalizedString("Common.Delete", comment: "Удалить"), systemImage: "trash")
+        }
+    }
+
+    private var supersetTitle: String {
+        groupExercises.map { $0.exercise.name }.joined(separator: "\n+ ")
+    }
+
+    private var supersetSummary: String? {
+        let count = supersetApproaches.count
+        guard count > 1 else { return nil }
+        return String(format: NSLocalizedString("WorkoutSetGroup.RepsMultiplier", comment: "× %d"), count)
+    }
+
+    private var supersetApproaches: [[(exercise: ExerciseInstance, approach: Approach)]] {
+        let minCount = groupExercises.map { $0.approaches.count }.min() ?? 0
+        return (0..<minCount).map { index in
+            groupExercises.map { ($0, $0.approaches[index]) }
+        }
+    }
+
+    private var simpleTitle: String {
+        let names = (groupExercises.isEmpty ? [exercise] : groupExercises).map { $0.exercise.name }
+        return names.joined(separator: " \u{2022} ")
     }
 }
 
@@ -31,11 +134,15 @@ struct WorkoutExerciseRowView: View {
 final class WorkoutExerciseRowViewModel: ObservableObject {}
 
 #Preview {
-    if let session = MockData.complexMockSessions.first {
+    if let session = MockData.complexMockSessions.first,
+       let first = session.exerciseInstances.first {
         WorkoutExerciseRowView(
-            exercise: session.exerciseInstances.first!,
+            exercise: first,
             group: session.setGroups?.first,
-            groupExercises: session.setGroups?.first.map { grp in session.exerciseInstances.filter { grp.exerciseInstanceIds.contains($0.id) } } ?? []
+            groupExercises: session.setGroups?.first.map { grp in
+                session.exerciseInstances.filter { grp.exerciseInstanceIds.contains($0.id) }
+            } ?? [],
+            onDelete: {}
         )
         .padding()
     }

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -72,7 +72,7 @@ struct WorkoutSessionView: View {
             VStack(alignment: .leading, spacing: 0) {
                 WorkoutSectionHeaderView(title: title)
 
-                VStack(spacing: Theme.spacing.small) {
+                LazyVStack(spacing: Theme.spacing.small) {
                     ForEach(exercises) { ex in
                         if let group = viewModel.group(for: ex), viewModel.isFirstExerciseInGroup(ex) {
                             let groupExercises = viewModel.groupExercises(for: group)
@@ -91,7 +91,7 @@ struct WorkoutSessionView: View {
                             )
                         }
                     }
-                } //: VStack
+                } //: LazyVStack
             }
         }
     }

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -76,16 +76,26 @@ struct WorkoutSessionView: View {
                     ForEach(exercises) { ex in
                         if let group = viewModel.group(for: ex), viewModel.isFirstExerciseInGroup(ex) {
                             let groupExercises = viewModel.groupExercises(for: group)
-                            if group.type == .superset {
-                                SupersetCell(group: group, exercises: groupExercises)
-                            } else {
-                                ExerciseBlockCard(group: group, exerciseInstances: groupExercises)
-                            }
+                            WorkoutExerciseRowView(exercise: ex, group: group, groupExercises: groupExercises)
+                                .swipeActions {
+                                    Button(role: .destructive) {
+                                        viewModel.deleteExercise(withId: ex.id)
+                                    } label: {
+                                        Label(NSLocalizedString("Common.Delete", comment: "Удалить"), systemImage: "trash")
+                                    }
+                                }
                         } else if !viewModel.isExerciseInAnyGroup(ex) {
-                            ExerciseBlockCard(group: nil, exerciseInstances: [ex])
+                            WorkoutExerciseRowView(exercise: ex)
+                                .swipeActions {
+                                    Button(role: .destructive) {
+                                        viewModel.deleteExercise(withId: ex.id)
+                                    } label: {
+                                        Label(NSLocalizedString("Common.Delete", comment: "Удалить"), systemImage: "trash")
+                                    }
+                                }
                         }
                     }
-                }
+                } //: VStack
             }
         }
     }

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -76,23 +76,19 @@ struct WorkoutSessionView: View {
                     ForEach(exercises) { ex in
                         if let group = viewModel.group(for: ex), viewModel.isFirstExerciseInGroup(ex) {
                             let groupExercises = viewModel.groupExercises(for: group)
-                            WorkoutExerciseRowView(exercise: ex, group: group, groupExercises: groupExercises)
-                                .swipeActions {
-                                    Button(role: .destructive) {
-                                        viewModel.deleteExercise(withId: ex.id)
-                                    } label: {
-                                        Label(NSLocalizedString("Common.Delete", comment: "Удалить"), systemImage: "trash")
-                                    }
-                                }
+                            WorkoutExerciseRowView(
+                                exercise: ex,
+                                group: group,
+                                groupExercises: groupExercises,
+                                onDelete: { viewModel.deleteExercise(withId: ex.id) }
+                            )
                         } else if !viewModel.isExerciseInAnyGroup(ex) {
-                            WorkoutExerciseRowView(exercise: ex)
-                                .swipeActions {
-                                    Button(role: .destructive) {
-                                        viewModel.deleteExercise(withId: ex.id)
-                                    } label: {
-                                        Label(NSLocalizedString("Common.Delete", comment: "Удалить"), systemImage: "trash")
-                                    }
-                                }
+                            WorkoutExerciseRowView(
+                                exercise: ex,
+                                group: nil,
+                                groupExercises: [],
+                                onDelete: { viewModel.deleteExercise(withId: ex.id) }
+                            )
                         }
                     }
                 } //: VStack

--- a/FitLink/Views/WorkoutSession/WorkoutSessionViewModel.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionViewModel.swift
@@ -61,10 +61,12 @@ final class WorkoutSessionViewModel: ObservableObject {
     }
 
     func deleteExercise(withId id: UUID) {
-        exercises.removeAll { $0.id == id }
-        for index in setGroups.indices {
-            setGroups[index].exerciseInstanceIds.removeAll { $0 == id }
+        if let groupIndex = setGroups.firstIndex(where: { $0.exerciseInstanceIds.contains(id) }) {
+            let ids = setGroups[groupIndex].exerciseInstanceIds
+            exercises.removeAll { ids.contains($0.id) }
+            setGroups.remove(at: groupIndex)
+        } else {
+            exercises.removeAll { $0.id == id }
         }
-        setGroups.removeAll { $0.exerciseInstanceIds.isEmpty }
     }
 }

--- a/FitLink/Views/WorkoutSession/WorkoutSessionViewModel.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionViewModel.swift
@@ -59,4 +59,12 @@ final class WorkoutSessionViewModel: ObservableObject {
             exercises.append(contentsOf: instances)
         }
     }
+
+    func deleteExercise(withId id: UUID) {
+        exercises.removeAll { $0.id == id }
+        for index in setGroups.indices {
+            setGroups[index].exerciseInstanceIds.removeAll { $0 == id }
+        }
+        setGroups.removeAll { $0.exerciseInstanceIds.isEmpty }
+    }
 }


### PR DESCRIPTION
## Summary
- create reusable `WorkoutExerciseRowView`
- support deleting exercises from `WorkoutSessionView`
- localize new "Delete" string
- handle exercise removal in the view model

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6852b1561cc483309a8330c0c367bc14