### PR TITLE
Add editing flow for workout items

### DIFF
--- a/FitLink/Localization/en.lproj/Localizable.strings
+++ b/FitLink/Localization/en.lproj/Localizable.strings
@@ -162,3 +162,4 @@
 "Common.Cancel" = "Cancel";
 "Common.Done" = "Done";
 "Common.Delete" = "Delete";
+"Common.Edit" = "Edit";

--- a/FitLink/Localization/ru.lproj/Localizable.strings
+++ b/FitLink/Localization/ru.lproj/Localizable.strings
@@ -162,3 +162,4 @@
 "Common.Cancel" = "Отмена";
 "Common.Done" = "Готово";
 "Common.Delete" = "Удалить";
+"Common.Edit" = "Изменить";

--- a/FitLink/UIAtoms/WorkoutScreen/WorkoutExerciseRowView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/WorkoutExerciseRowView.swift
@@ -4,6 +4,7 @@ struct WorkoutExerciseRowView: View {
     let exercise: ExerciseInstance
     let group: SetGroup?
     var groupExercises: [ExerciseInstance] = []
+    var onEdit: () -> Void
     var onDelete: () -> Void
 
     var body: some View {
@@ -11,7 +12,10 @@ struct WorkoutExerciseRowView: View {
             content
         } //: ZStack
         .contentShape(Rectangle())
-        .swipeActions {
+        .swipeActions(allowsFullSwipe: false) {
+            Button(action: onEdit) {
+                Label(NSLocalizedString("Common.Edit", comment: "Edit"), systemImage: "pencil")
+            }
             Button(role: .destructive, action: onDelete) {
                 Text(NSLocalizedString("Common.Delete", comment: "Delete"))
             }
@@ -35,6 +39,6 @@ struct WorkoutExerciseRowView: View {
 #Preview {
     let session = MockData.complexMockSessions.first!
     let exercise = session.exerciseInstances.first!
-    return WorkoutExerciseRowView(exercise: exercise, group: nil, onDelete: {})
+    return WorkoutExerciseRowView(exercise: exercise, group: nil, onEdit: {}, onDelete: {})
         .padding()
 }

--- a/FitLink/UIAtoms/WorkoutScreen/WorkoutExerciseRowView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/WorkoutExerciseRowView.swift
@@ -14,10 +14,12 @@ struct WorkoutExerciseRowView: View {
         .contentShape(Rectangle())
         .swipeActions(allowsFullSwipe: false) {
             Button(action: onEdit) {
-                Label(NSLocalizedString("Common.Edit", comment: "Edit"), systemImage: "pencil")
+                Label(NSLocalizedString("Common.Edit", comment: "Edit"), systemImage: "gearshape")
+                    .labelStyle(.iconOnly)
             }
             Button(role: .destructive, action: onDelete) {
-                Text(NSLocalizedString("Common.Delete", comment: "Delete"))
+                Label(NSLocalizedString("Common.Delete", comment: "Delete"), systemImage: "trash")
+                    .labelStyle(.iconOnly)
             }
         }
     }

--- a/FitLink/Views/WorkoutSession/WorkoutExerciseEditView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutExerciseEditView.swift
@@ -41,10 +41,9 @@ struct WorkoutExerciseEditView: View {
                 }
             }
             .sheet(isPresented: $showLibrary) {
-                let index = libraryIndex
                 ExerciseLibraryView { exercise in
-                    if index < viewModel.selectedExercises.count {
-                        viewModel.replaceExercise(at: index, with: exercise)
+                    if libraryIndex < viewModel.selectedExercises.count {
+                        viewModel.replaceExercise(at: libraryIndex, with: exercise)
                     } else {
                         viewModel.addExercise(exercise)
                     }

--- a/FitLink/Views/WorkoutSession/WorkoutExerciseEditView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutExerciseEditView.swift
@@ -5,9 +5,16 @@ struct WorkoutExerciseEditView: View {
     var onComplete: (WorkoutExerciseEditResult) -> Void
 
     @Environment(\.dismiss) private var dismiss
-    @StateObject private var viewModel = WorkoutExerciseEditViewModel()
+    @StateObject private var viewModel: WorkoutExerciseEditViewModel
+    private let isEditing: Bool
     @State private var libraryIndex: Int = 0
     @State private var showLibrary = false
+
+    init(initialExercises: [Exercise] = [], onComplete: @escaping (WorkoutExerciseEditResult) -> Void) {
+        self.onComplete = onComplete
+        _viewModel = StateObject(wrappedValue: WorkoutExerciseEditViewModel(initialExercises: initialExercises))
+        self.isEditing = !initialExercises.isEmpty
+    }
 
     var body: some View {
         NavigationStack {
@@ -17,7 +24,7 @@ struct WorkoutExerciseEditView: View {
                 } //: VStack
                 .padding(Theme.spacing.medium)
             }
-            .navigationTitle(NSLocalizedString("WorkoutExerciseEdit.AddTitle", comment: "Add Exercise"))
+            .navigationTitle(isEditing ? NSLocalizedString("WorkoutExerciseEdit.EditTitle", comment: "Edit Exercise") : NSLocalizedString("WorkoutExerciseEdit.AddTitle", comment: "Add Exercise"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {

--- a/FitLink/Views/WorkoutSession/WorkoutExerciseEditViewModel.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutExerciseEditViewModel.swift
@@ -2,7 +2,11 @@ import Foundation
 
 @MainActor
 final class WorkoutExerciseEditViewModel: ObservableObject {
-    @Published var selectedExercises: [Exercise] = []
+    @Published var selectedExercises: [Exercise]
+
+    init(initialExercises: [Exercise] = []) {
+        self.selectedExercises = initialExercises
+    }
 
     var isSuperset: Bool { selectedExercises.count > 1 }
 

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -39,8 +39,8 @@ struct WorkoutSessionView: View {
         }
         .presentationDetents([.medium, .large])
         .sheet(isPresented: $viewModel.showExerciseEdit) {
-            WorkoutExerciseEditView { result in
-                viewModel.addItem(result)
+            WorkoutExerciseEditView(initialExercises: viewModel.editingContext?.exercises ?? []) { result in
+                viewModel.completeEdit(result)
             }
         }
     }
@@ -81,6 +81,7 @@ struct WorkoutSessionView: View {
                             exercise: ex,
                             group: group,
                             groupExercises: groupExercises,
+                            onEdit: { viewModel.editItemTapped(withId: group.id) },
                             onDelete: { viewModel.deleteItem(withId: group.id) }
                         )
                         .listRowSeparator(.hidden)
@@ -88,6 +89,7 @@ struct WorkoutSessionView: View {
                         WorkoutExerciseRowView(
                             exercise: ex,
                             group: nil,
+                            onEdit: { viewModel.editItemTapped(withId: ex.id) },
                             onDelete: { viewModel.deleteItem(withId: ex.id) }
                         )
                         .listRowSeparator(.hidden)

--- a/FitLink/Views/WorkoutSession/WorkoutSessionViewModel.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionViewModel.swift
@@ -112,7 +112,7 @@ final class WorkoutSessionViewModel: ObservableObject {
         switch result {
         case .single(var instance):
             if let old = context.instances.first,
-               old.exercise.metrics.map(\.$type) == instance.exercise.metrics.map(\.$type) {
+               old.exercise.metrics.map(\.type) == instance.exercise.metrics.map(\.type) {
                 instance.approaches = old.approaches
                 instance.notes = old.notes
             }
@@ -124,7 +124,7 @@ final class WorkoutSessionViewModel: ObservableObject {
                 var item = instances[i]
                 if context.instances.indices.contains(i) {
                     let old = context.instances[i]
-                    if old.exercise.metrics.map(\.$type) == item.exercise.metrics.map(\.$type) {
+                    if old.exercise.metrics.map(\.type) == item.exercise.metrics.map(\.type) {
                         item.approaches = old.approaches
                         item.notes = old.notes
                     }


### PR DESCRIPTION
## Summary
- enable editing of workout items via swipe action
- prepopulate Exercise selection sheet when editing
- replace items or groups in the session
- localize new common "Edit" string

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6852d3125b6c833099100f94d5b4379c