### PR TITLE
Enable deleting exercises during edit

### DIFF
--- a/FitLink/Views/WorkoutSession/WorkoutExerciseEditView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutExerciseEditView.swift
@@ -82,22 +82,34 @@ struct WorkoutExerciseEditView: View {
 
     @ViewBuilder
     private func exerciseCard(for exercise: Exercise, index: Int) -> some View {
-        Button(action: { libraryIndex = index; showLibrary = true }) {
-            HStack {
-                Image(systemName: exercise.mainMuscle.iconName)
-                    .font(.largeTitle)
-                    .foregroundColor(exercise.mainMuscle.color)
-                Text(exercise.name)
-                    .font(Theme.font.titleMedium.bold())
-                Spacer()
-                Text(NSLocalizedString("WorkoutExerciseEdit.Change", comment: "Replace"))
-                    .font(Theme.font.body)
-                    .foregroundColor(.secondary)
+        ZStack(alignment: .topTrailing) {
+            Button(action: { libraryIndex = index; showLibrary = true }) {
+                HStack {
+                    Image(systemName: exercise.mainMuscle.iconName)
+                        .font(.largeTitle)
+                        .foregroundColor(exercise.mainMuscle.color)
+                    Text(exercise.name)
+                        .font(Theme.font.titleMedium.bold())
+                    Spacer()
+                    Text(NSLocalizedString("WorkoutExerciseEdit.Change", comment: "Replace"))
+                        .font(Theme.font.body)
+                        .foregroundColor(.secondary)
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Theme.color.backgroundSecondary)
+                .cornerRadius(Theme.radius.card)
             }
-            .padding()
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Theme.color.backgroundSecondary)
-            .cornerRadius(Theme.radius.card)
+            Button(role: .destructive) {
+                if viewModel.removeExercise(at: index) && isEditing {
+                    onComplete(.deleted)
+                    dismiss()
+                }
+            } label: {
+                Image(systemName: "trash")
+                    .padding(8)
+            }
+            .accessibilityLabel(NSLocalizedString("Common.Delete", comment: "Delete"))
         }
     }
 }

--- a/FitLink/Views/WorkoutSession/WorkoutExerciseEditViewModel.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutExerciseEditViewModel.swift
@@ -19,6 +19,13 @@ final class WorkoutExerciseEditViewModel: ObservableObject {
         selectedExercises[index] = exercise
     }
 
+    /// Remove exercise at index. Returns `true` if no exercises remain.
+    func removeExercise(at index: Int) -> Bool {
+        guard selectedExercises.indices.contains(index) else { return false }
+        selectedExercises.remove(at: index)
+        return selectedExercises.isEmpty
+    }
+
     func confirmSelection() -> WorkoutExerciseEditResult? {
         guard !selectedExercises.isEmpty else { return nil }
         if selectedExercises.count == 1, let exercise = selectedExercises.first {
@@ -58,4 +65,5 @@ final class WorkoutExerciseEditViewModel: ObservableObject {
 enum WorkoutExerciseEditResult {
     case single(ExerciseInstance)
     case superset(group: SetGroup, exercises: [ExerciseInstance])
+    case deleted
 }

--- a/FitLink/Views/WorkoutSession/WorkoutSessionViewModel.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionViewModel.swift
@@ -89,6 +89,8 @@ final class WorkoutSessionViewModel: ObservableObject {
         case .superset(let group, let instances):
             setGroups.append(group)
             exercises.append(contentsOf: instances)
+        case .deleted:
+            break
         }
     }
 
@@ -134,12 +136,22 @@ final class WorkoutSessionViewModel: ObservableObject {
             }
             setGroups.append(group)
             exercises.insert(contentsOf: instances, at: insertionIndex)
+        case .deleted:
+            // Handled outside this switch
+            break
         }
     }
 
     func completeEdit(_ result: WorkoutExerciseEditResult) {
         if editingContext != nil {
-            replaceItem(result)
+            if case .deleted = result {
+                deleteItem(withId: editingContext!.id)
+            } else {
+                replaceItem(result)
+            }
+        } else if case .deleted = result {
+            // nothing to delete
+            return
         } else {
             addItem(result)
         }


### PR DESCRIPTION
## Summary
- allow exercises to be removed while editing
- handle delete result in WorkoutSessionViewModel
- show a trash button in edit cards

## Testing
- `swift build -c release` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6852f1ad51308330891a3e942069f72d