### PR TITLE
Refactor sets list to horizontal cards

### DIFF
--- a/FitLink/UIAtoms/WorkoutScreen/ApproachCardView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachCardView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+/// Visual representation of a single approach/set displayed inside a horizontal list.
+struct ApproachCardView: View {
+    let set: ExerciseSet
+    let metrics: [ExerciseMetric]
+
+    private var weightMetric: ExerciseMetric? {
+        metrics.first { $0.type == .weight }
+    }
+
+    private var repsMetric: ExerciseMetric? {
+        metrics.first { $0.type == .reps }
+    }
+
+    private var timeMetric: ExerciseMetric? {
+        metrics.first { $0.type == .time }
+    }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            let drops = [set] + (set.drops ?? [])
+            ForEach(drops.indices, id: \.self) { idx in
+                VStack(spacing: 2) {
+                    Text(weightString(for: drops[idx]))
+                        .font(Theme.font.body.bold())
+                    Text(metricString(for: drops[idx]))
+                        .font(Theme.font.caption)
+                        .foregroundColor(Theme.color.textSecondary)
+                }
+                if idx < drops.count - 1 {
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .padding(Theme.spacing.small)
+        .frame(minWidth: 64, maxHeight: .infinity)
+        .background(Theme.color.backgroundSecondary)
+        .cornerRadius(Theme.radius.card)
+    }
+
+    private func weightString(for set: ExerciseSet) -> String {
+        guard let weightMetric else { return "" }
+        return set.metricValues[.weight].map { ExerciseMetric.formattedMetric($0, metric: weightMetric) } ?? ""
+    }
+
+    private func metricString(for set: ExerciseSet) -> String {
+        if let repsMetric, let value = set.metricValues[.reps] {
+            return ExerciseMetric.formattedMetric(value, metric: repsMetric)
+        }
+        if let timeMetric, let value = set.metricValues[.time] {
+            return ExerciseMetric.formattedMetric(value, metric: timeMetric)
+        }
+        return ""
+    }
+}
+
+#Preview {
+    let metrics = [ExerciseMetric(type: .reps, unit: .repetition, isRequired: true),
+                   ExerciseMetric(type: .weight, unit: .kilogram, isRequired: false)]
+    let set1 = ExerciseSet(id: UUID(), metricValues: [.weight: 50, .reps: 8], notes: nil, drops: [ExerciseSet(id: UUID(), metricValues: [.weight: 40, .reps: 8], notes: nil, drops: nil)])
+    return ApproachCardView(set: set1, metrics: metrics)
+        .frame(height: 64)
+        .padding()
+}

--- a/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+/// Horizontally scrollable list of exercise approaches.
+struct ApproachListView: View {
+    let sets: [ExerciseSet]
+    let metrics: [ExerciseMetric]
+    var onTap: () -> Void = {}
+
+    private var gridRows: [GridItem] { [GridItem(.fixed(64))] }
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            LazyHGrid(rows: gridRows, spacing: Theme.spacing.small) {
+                if sets.isEmpty {
+                    Button(action: onTap) {
+                        Image(systemName: "plus")
+                            .frame(width: 64, height: 64)
+                            .foregroundColor(.gray)
+                            .background(Theme.color.backgroundSecondary)
+                            .cornerRadius(Theme.radius.card)
+                    }
+                } else {
+                    ForEach(sets) { set in
+                        Button(action: onTap) {
+                            ApproachCardView(set: set, metrics: metrics)
+                                .frame(height: 64)
+                        }
+                    }
+                }
+            }
+            .padding(.vertical, Theme.spacing.small)
+        } //: ScrollView
+    }
+}
+
+#Preview {
+    let metrics = [ExerciseMetric(type: .reps, unit: .repetition, isRequired: true),
+                   ExerciseMetric(type: .weight, unit: .kilogram, isRequired: false)]
+    let set1 = ExerciseSet(id: UUID(), metricValues: [.weight: 50, .reps: 8], notes: nil, drops: nil)
+    return ApproachListView(sets: [set1], metrics: metrics)
+        .padding()
+}

--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct ExerciseBlockCard: View {
     let group: SetGroup?
     let exerciseInstances: [ExerciseInstance]
+    var onEdit: () -> Void = {}
 
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.spacing.small) {
@@ -19,13 +20,14 @@ struct ExerciseBlockCard: View {
                 .truncationMode(.tail)
 
             if let main = exerciseInstances.first {
-                ExerciseSetMetricsView(
+                ApproachListView(
                     sets: main.approaches.map { approach in
                         var first = approach.sets.first ?? ExerciseSet(id: UUID(), metricValues: [:], notes: nil, drops: nil)
                         first.drops = Array(approach.sets.dropFirst())
                         return first
                     },
-                    metrics: main.exercise.metrics
+                    metrics: main.exercise.metrics,
+                    onTap: onEdit
                 )
             }
         }

--- a/FitLink/UIAtoms/WorkoutScreen/SupersetCell.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/SupersetCell.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct SupersetCell: View {
     let group: SetGroup
     let exercises: [ExerciseInstance]
+    var onEdit: () -> Void = {}
 
     @State private var isExpanded = false
 
@@ -37,6 +38,7 @@ struct SupersetCell: View {
                                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                                     .fill(Theme.color.supersetSubcardBackground)
                             )
+                            .onTapGesture { onEdit() }
                     }
                 }
                 .padding(.top, Theme.spacing.small)

--- a/FitLink/UIAtoms/WorkoutScreen/WorkoutExerciseRowView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/WorkoutExerciseRowView.swift
@@ -28,12 +28,12 @@ struct WorkoutExerciseRowView: View {
     private var content: some View {
         if let group, !groupExercises.isEmpty {
             if group.type == .superset {
-                SupersetCell(group: group, exercises: groupExercises)
+                SupersetCell(group: group, exercises: groupExercises, onEdit: onEdit)
             } else {
-                ExerciseBlockCard(group: group, exerciseInstances: groupExercises)
+                ExerciseBlockCard(group: group, exerciseInstances: groupExercises, onEdit: onEdit)
             }
         } else {
-            ExerciseBlockCard(group: nil, exerciseInstances: [exercise])
+            ExerciseBlockCard(group: nil, exerciseInstances: [exercise], onEdit: onEdit)
         }
     }
 }


### PR DESCRIPTION
## Summary
- introduce `ApproachCardView` to render a single workout approach
- add `ApproachListView` with `ScrollView + LazyHGrid` for horizontal scrolling
- use the new list in `ExerciseBlockCard`
- forward edit action through row and superset views

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685309970eb48330898e0fd8d728f29a