### PR TITLE
Fix metric tap and scroll gestures in superset view

### DIFF
--- a/FitLink/UIAtoms/WorkoutScreen/ApproachCardView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachCardView.swift
@@ -42,6 +42,7 @@ struct ApproachCardView: View {
         .frame(minWidth: 64, maxHeight: .infinity)
         .background(Theme.color.textSecondary.opacity(0.05))
         .cornerRadius(Theme.radius.card)
+        .contentShape(Rectangle())
     }
 
     private func weightString(for set: ExerciseSet) -> String? {

--- a/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
@@ -12,25 +12,26 @@ struct ApproachListView: View {
         ScrollView(.horizontal, showsIndicators: false) {
             LazyHGrid(rows: gridRows, spacing: Theme.spacing.small) {
                 if sets.isEmpty {
-                    Image(systemName: "plus")
-                        .frame(width: 64, height: 64)
-                        .foregroundColor(.primary)
-                        .background(Theme.color.backgroundSecondary)
-                        .cornerRadius(Theme.radius.card)
-                        .contentShape(Rectangle())
-                        .highPriorityGesture(TapGesture().onEnded(onTap))
+                    Button(action: onTap) {
+                        Image(systemName: "plus")
+                            .frame(width: 64, height: 64)
+                            .foregroundColor(.primary)
+                            .background(Theme.color.backgroundSecondary)
+                            .cornerRadius(Theme.radius.card)
+                    }
+                    .buttonStyle(.plain)
                 } else {
                     ForEach(sets) { set in
-                        ApproachCardView(set: set, metrics: metrics)
-                            .frame(height: 64)
-                            .contentShape(Rectangle())
-                            .highPriorityGesture(TapGesture().onEnded(onTap))
+                        Button(action: onTap) {
+                            ApproachCardView(set: set, metrics: metrics)
+                                .frame(height: 64)
+                        }
+                        .buttonStyle(.plain)
                     }
                 }
             }
             .padding(.vertical, Theme.spacing.small)
-        }
-        .highPriorityGesture(DragGesture()) // ensure horizontal scroll isn't intercepted
+        } //: ScrollView
     }
 }
 

--- a/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
@@ -18,19 +18,24 @@ struct ApproachListView: View {
                             .foregroundColor(.primary)
                             .background(Theme.color.backgroundSecondary)
                             .cornerRadius(Theme.radius.card)
+                            .contentShape(Rectangle())
                     }
+                    .buttonStyle(.plain)
                 } else {
                     ForEach(sets) { set in
                         Button(action: onTap) {
                             ApproachCardView(set: set, metrics: metrics)
                                 .frame(height: 64)
-                            
+                                .contentShape(Rectangle())
                         }
+                        .buttonStyle(.plain)
                     }
                 }
             }
+            .contentShape(Rectangle())
             .padding(.vertical, Theme.spacing.small)
-        } //: ScrollView
+        }
+        .highPriorityGesture(DragGesture()) // ensure horizontal scroll isn't intercepted
     }
 }
 

--- a/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
@@ -12,27 +12,22 @@ struct ApproachListView: View {
         ScrollView(.horizontal, showsIndicators: false) {
             LazyHGrid(rows: gridRows, spacing: Theme.spacing.small) {
                 if sets.isEmpty {
-                    Button(action: onTap) {
-                        Image(systemName: "plus")
-                            .frame(width: 64, height: 64)
-                            .foregroundColor(.primary)
-                            .background(Theme.color.backgroundSecondary)
-                            .cornerRadius(Theme.radius.card)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
+                    Image(systemName: "plus")
+                        .frame(width: 64, height: 64)
+                        .foregroundColor(.primary)
+                        .background(Theme.color.backgroundSecondary)
+                        .cornerRadius(Theme.radius.card)
+                        .contentShape(Rectangle())
+                        .highPriorityGesture(TapGesture().onEnded(onTap))
                 } else {
                     ForEach(sets) { set in
-                        Button(action: onTap) {
-                            ApproachCardView(set: set, metrics: metrics)
-                                .frame(height: 64)
-                                .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
+                        ApproachCardView(set: set, metrics: metrics)
+                            .frame(height: 64)
+                            .contentShape(Rectangle())
+                            .highPriorityGesture(TapGesture().onEnded(onTap))
                     }
                 }
             }
-            .contentShape(Rectangle())
             .padding(.vertical, Theme.spacing.small)
         }
         .highPriorityGesture(DragGesture()) // ensure horizontal scroll isn't intercepted

--- a/FitLink/UIAtoms/WorkoutScreen/SupersetApproachView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/SupersetApproachView.swift
@@ -25,27 +25,14 @@ struct SupersetApproachView: View {
                 VStack(alignment: .leading, spacing: Theme.spacing.small / 2) {
                     Text(item.exercise.exercise.name)
                         .font(Theme.font.body).bold()
-                    Button(action: { onSetsEdit(item.exercise) }) {
-                        if let approach = item.approach {
-                            ApproachCardView(set: approachSet(from: approach), metrics: item.exercise.exercise.metrics)
-                                .frame(height: 64)
-                        } else {
-                            Image(systemName: "plus")
-                                .frame(minWidth: 64, maxHeight: .infinity)
-                                .frame(height: 64)
-                                .foregroundColor(.secondary)
-                                .background(Theme.color.textSecondary.opacity(0.05))
-                                .cornerRadius(Theme.radius.card)
-                        }
-                    }
+                    ApproachListView(
+                        sets: item.approach?.sets ?? [],
+                        metrics: item.exercise.exercise.metrics,
+                        onTap: { onSetsEdit(item.exercise) }
+                    )
                 }
             }
         }
     }
 
-    private func approachSet(from approach: Approach) -> ExerciseSet {
-        var first = approach.sets.first ?? ExerciseSet(id: UUID(), metricValues: [:], notes: nil, drops: nil)
-        first.drops = Array(approach.sets.dropFirst())
-        return first
-    }
 }

--- a/FitLink/UIAtoms/WorkoutScreen/SupersetCell.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/SupersetCell.swift
@@ -49,13 +49,12 @@ struct SupersetCell: View {
                         SupersetApproachView(index: idx + 1, items: data) { ex in
                             onSetsEdit(ex, idx)
                         }
-                            .padding(Theme.spacing.small)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(
-                                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                    .fill(Theme.color.supersetSubcardBackground)
-                            )
-                            .onTapGesture { onEdit() }
+                        .padding(Theme.spacing.small)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .fill(Theme.color.supersetSubcardBackground)
+                        )
                     }
                 }
                 .padding(.top, Theme.spacing.small)


### PR DESCRIPTION
## Summary
- ensure metric cards capture taps and drags
- use `ApproachListView` inside superset approach rows
- drop tap gesture on approach row to avoid intercepting inner views

## Testing
- `swift --version`
- `xcodebuild -list -project FitLink.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532b07be4083309a2b9d7fd7f190b4