### PR TITLE
Fix superset placeholder rendering

### DIFF
--- a/FitLink/UIAtoms/WorkoutScreen/SupersetCell.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/SupersetCell.swift
@@ -25,6 +25,9 @@ struct SupersetCell: View {
 
     private var approaches: [[(exercise: ExerciseInstance, approach: Approach?)]] {
         let maxCount = exercises.map { $0.approaches.count }.max() ?? 0
+        if maxCount == 0 {
+            return [exercises.map { ($0, nil) }]
+        }
         return (0..<maxCount).map { index in
             exercises.map { ($0, $0.approaches[safe: index]) }
         }


### PR DESCRIPTION
## Summary
- ensure SupersetCell shows at least one approach block

## Testing
- `swiftc -parse -target x86_64-apple-macosx10.15 FitLink/UIAtoms/WorkoutScreen/SupersetCell.swift`


------
https://chatgpt.com/codex/tasks/task_e_6853350d0b9083308fdb8e4bbd7f596c