### PR TITLE
Improve set/drop editors UX

### DIFF
--- a/FitLink/App/FitLinkApp.swift
+++ b/FitLink/App/FitLinkApp.swift
@@ -9,9 +9,12 @@ import SwiftUI
 
 @main
 struct FitLinkApp: App {
+    @StateObject private var store = WorkoutStore()
+
     var body: some Scene {
         WindowGroup {
             MainView()
+                .environmentObject(store)
         }
     }
 }

--- a/FitLink/CommonServices/WorkoutStore.swift
+++ b/FitLink/CommonServices/WorkoutStore.swift
@@ -23,4 +23,9 @@ final class WorkoutStore: ObservableObject {
         guard let eIndex = sessions[sIndex].exerciseInstances.firstIndex(where: { $0.id == exercise.id }) else { return }
         sessions[sIndex].exerciseInstances[eIndex] = exercise
     }
+
+    func updateSession(_ session: WorkoutSession) {
+        guard let index = sessions.firstIndex(where: { $0.id == session.id }) else { return }
+        sessions[index] = session
+    }
 }

--- a/FitLink/Helpers/String+Ext.swift
+++ b/FitLink/Helpers/String+Ext.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension String {
+    /// Removes leading zeros except before decimal point
+    func trimLeadingZeros() -> String {
+        var result = self
+        while result.hasPrefix("0") && result.count > 1 && !result.hasPrefix("0.") {
+            result.removeFirst()
+        }
+        return result
+    }
+}

--- a/FitLink/Localization/en.lproj/Localizable.strings
+++ b/FitLink/Localization/en.lproj/Localizable.strings
@@ -159,11 +159,11 @@
 "WorkoutExerciseEdit.AddAnotherExercise" = "Add Another Exercise";
 
 /* Metric Editor */
-"MetricEditor.Title" = "Edit Sets";
+"MetricEditor.Title" = "Sets";
 "MetricEditor.AddSet" = "Add Set";
 
 /* Drop editor */
-"DropEditor.Title" = "Edit Drops";
+"DropEditor.Title" = "Drops";
 "DropEditor.AddDrop" = "Add Drop";
 
 /* Common */

--- a/FitLink/Localization/ru.lproj/Localizable.strings
+++ b/FitLink/Localization/ru.lproj/Localizable.strings
@@ -159,11 +159,11 @@
 "WorkoutExerciseEdit.AddAnotherExercise" = "Добавить ещё одно упражнение";
 
 /* Metric Editor */
-"MetricEditor.Title" = "Редактирование сетов";
+"MetricEditor.Title" = "Сеты";
 "MetricEditor.AddSet" = "Добавить сет";
 
 /* Drop editor */
-"DropEditor.Title" = "Редактирование дропов";
+"DropEditor.Title" = "Дропы";
 "DropEditor.AddDrop" = "Добавить дроп";
 
 /* Common */

--- a/FitLink/UIAtoms/WorkoutScreen/MetricInputField.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/MetricInputField.swift
@@ -8,6 +8,7 @@ struct MetricInputField: View {
 
     @State private var text: String = ""
     @FocusState private var focused: Bool
+    var onCommit: (() -> Void)? = nil
 
     var body: some View {
         HStack {
@@ -23,10 +24,14 @@ struct MetricInputField: View {
                 TextField("0", text: $text)
                     .focused($focused)
                     .keyboardType(.decimalPad)
-                    .multilineTextAlignment(.trailing)
+                    .multilineTextAlignment(.center)
+                    .frame(minWidth: 48, minHeight: 48)
+                    .padding(.horizontal, 4)
+                    .background(RoundedRectangle(cornerRadius: 8).stroke(focused ? Theme.color.accent : Color.gray.opacity(0.3)))
                     .onTapGesture { handleTap() }
                     .onChange(of: text) { newValue in
                         text = newValue.trimLeadingZeros()
+                        syncBinding()
                     }
                 if metric.type != .reps {
                     Text(metric.unit?.displayName ?? "")
@@ -34,10 +39,10 @@ struct MetricInputField: View {
                 }
             }
             .font(Theme.font.body.bold())
-            .padding(6)
-            .background(RoundedRectangle(cornerRadius: 8).stroke(Color.gray.opacity(0.3)))
         }
-        .onAppear { text = formattedValue }
+        .onAppear {
+            text = formattedValue
+        }
         .onChange(of: focused) { newValue in
             if !newValue { commit() }
         }
@@ -59,6 +64,14 @@ struct MetricInputField: View {
         DispatchQueue.main.async { self.focused = true }
     }
 
+    private func syncBinding() {
+        guard let number = Double(text), number != 0 else {
+            value = nil
+            return
+        }
+        value = number
+    }
+
     private func commit() {
         guard let number = Double(text), number != 0 else {
             value = nil
@@ -66,6 +79,7 @@ struct MetricInputField: View {
             return
         }
         value = number
+        onCommit?()
     }
 }
 

--- a/FitLink/UIAtoms/WorkoutScreen/MetricInputField.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/MetricInputField.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+/// Editable metric field with optional label, prefix and suffix
+struct MetricInputField: View {
+    @Binding var value: Double?
+    let metric: ExerciseMetric
+    var showLabel: Bool = true
+
+    @State private var text: String = ""
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        HStack {
+            if showLabel {
+                Text(metric.displayName)
+                Spacer()
+            }
+            HStack(spacing: 4) {
+                if metric.type == .reps {
+                    Text("x")
+                        .foregroundColor(.secondary)
+                }
+                TextField("0", text: $text)
+                    .focused($focused)
+                    .keyboardType(.decimalPad)
+                    .multilineTextAlignment(.trailing)
+                    .onTapGesture { handleTap() }
+                    .onChange(of: text) { newValue in
+                        text = newValue.trimLeadingZeros()
+                    }
+                if metric.type != .reps {
+                    Text(metric.unit?.displayName ?? "")
+                        .foregroundColor(.secondary)
+                }
+            }
+            .font(Theme.font.body.bold())
+            .padding(6)
+            .background(RoundedRectangle(cornerRadius: 8).stroke(Color.gray.opacity(0.3)))
+        }
+        .onAppear { text = formattedValue }
+        .onChange(of: focused) { newValue in
+            if !newValue { commit() }
+        }
+    }
+
+    private var formattedValue: String {
+        guard let value else { return "" }
+        if value == floor(value) {
+            return String(Int(value))
+        } else {
+            return String(format: "%.1f", value)
+        }
+    }
+
+    private func handleTap() {
+        if text == "0" {
+            text = ""
+        }
+        DispatchQueue.main.async { self.focused = true }
+    }
+
+    private func commit() {
+        guard let number = Double(text), number != 0 else {
+            value = nil
+            text = ""
+            return
+        }
+        value = number
+    }
+}
+
+#Preview {
+    MetricInputField(value: .constant(12), metric: ExerciseMetric(type: .reps, unit: .repetition, isRequired: true))
+        .padding()
+}

--- a/FitLink/UIAtoms/WorkoutScreen/SupersetApproachView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/SupersetApproachView.swift
@@ -1,9 +1,3 @@
-//
-//  Untitled.swift
-//  FitLink
-//
-//  Created by Дмитрий Гришечко on 16.06.2025.
-//
 import SwiftUI
 
 /// View representing a single approach in the superset.
@@ -26,13 +20,26 @@ struct SupersetApproachView: View {
                     Text(item.exercise.exercise.name)
                         .font(Theme.font.body).bold()
                     ApproachListView(
-                        sets: item.approach?.sets ?? [],
+                        sets: combinedSets(for: item.approach),
                         metrics: item.exercise.exercise.metrics,
                         onTap: { onSetsEdit(item.exercise) }
                     )
                 }
             }
-        }
+        } //: VStack
     }
 
+    private func combinedSets(for approach: Approach?) -> [ExerciseSet] {
+        guard let approach else { return [] }
+        var first = approach.sets.first ?? ExerciseSet(id: UUID(), metricValues: [:], notes: nil, drops: nil)
+        first.drops = Array(approach.sets.dropFirst())
+        return [first]
+    }
+}
+
+#Preview {
+    let metrics = [ExerciseMetric(type: .reps, unit: .repetition, isRequired: true),
+                   ExerciseMetric(type: .weight, unit: .kilogram, isRequired: false)]
+    let ex = ExerciseInstance(id: UUID(), exercise: Exercise(id: UUID(), name: "Test", variations: [], muscleGroups: [.chest], metrics: metrics), approaches: [], groupId: nil, notes: nil)
+    return SupersetApproachView(index: 1, items: [(ex, nil)])
 }

--- a/FitLink/Views/Schedule/ScheduleView.swift
+++ b/FitLink/Views/Schedule/ScheduleView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 struct ScheduleView: View {
     @StateObject private var viewModel = ScheduleViewModel()
     @State private var selectedSession: WorkoutSession?
+    @EnvironmentObject private var store: WorkoutStore
 
     var body: some View {
         NavigationStack {
@@ -86,7 +87,7 @@ struct ScheduleView: View {
             .background(Theme.color.background)
             .navigationDestination(item: $selectedSession) { session in
                 let client = session.clientId.flatMap { viewModel.clients[$0] }
-                WorkoutSessionView(session: session, client: client)
+                WorkoutSessionView(session: session, client: client, store: store)
             }
             .navigationBarHidden(true)
             
@@ -96,4 +97,5 @@ struct ScheduleView: View {
 
 #Preview {
     ScheduleView()
+        .environmentObject(WorkoutStore())
 }

--- a/FitLink/Views/WorkoutSession/DropSetEditorView.swift
+++ b/FitLink/Views/WorkoutSession/DropSetEditorView.swift
@@ -36,6 +36,9 @@ struct DropSetEditorView: View {
                 }
             }
             .listStyle(.plain)
+            .simultaneousGesture(
+                TapGesture().onEnded { _ in hideKeyboard() }
+            )
             .navigationTitle(NSLocalizedString("DropEditor.Title", comment: "Edit Drops"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -44,6 +47,7 @@ struct DropSetEditorView: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button(NSLocalizedString("Common.Done", comment: "Done")) {
+                        hideKeyboard()
                         onComplete(viewModel.sets)
                         dismiss()
                     }

--- a/FitLink/Views/WorkoutSession/DropSetEditorView.swift
+++ b/FitLink/Views/WorkoutSession/DropSetEditorView.swift
@@ -27,13 +27,17 @@ struct DropSetEditorView: View {
                 .onDelete(perform: viewModel.deleteDrops)
 
                 Button(action: viewModel.addDrop) {
-                    HStack {
-                        Spacer()
-                        Image(systemName: "plus")
-                        Text(NSLocalizedString("DropEditor.AddDrop", comment: "Add Drop"))
-                        Spacer()
-                    }
+                    Image(systemName: "plus")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Theme.color.backgroundSecondary)
+                        .cornerRadius(Theme.radius.card)
                 }
+                .buttonStyle(.plain)
+                .listRowInsets(EdgeInsets(top: 0,
+                                         leading: Theme.spacing.large,
+                                         bottom: 0,
+                                         trailing: Theme.spacing.large))
             }
             .listStyle(.plain)
             .simultaneousGesture(

--- a/FitLink/Views/WorkoutSession/DropSetEditorView.swift
+++ b/FitLink/Views/WorkoutSession/DropSetEditorView.swift
@@ -16,7 +16,7 @@ struct DropSetEditorView: View {
         NavigationStack {
             List {
                 ForEach(viewModel.sets.indices, id: \.self) { idx in
-                    SetEditorRow(set: $viewModel.sets[idx], metrics: viewModel.metrics)
+                    SetEditorRow(set: $viewModel.sets[idx], metrics: viewModel.metrics, showLabels: false)
                         .listRowSeparator(.hidden)
                         .overlay(alignment: .topLeading) {
                             Text(label(for: idx))
@@ -25,7 +25,6 @@ struct DropSetEditorView: View {
                         }
                 }
                 .onDelete(perform: viewModel.deleteDrops)
-                .onMove(perform: viewModel.moveDrops)
 
                 Button(action: viewModel.addDrop) {
                     HStack {
@@ -40,7 +39,6 @@ struct DropSetEditorView: View {
             .navigationTitle(NSLocalizedString("DropEditor.Title", comment: "Edit Drops"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) { EditButton() }
                 ToolbarItem(placement: .cancellationAction) {
                     Button(NSLocalizedString("Common.Cancel", comment: "Cancel")) { dismiss() }
                 }

--- a/FitLink/Views/WorkoutSession/MetricEditorView.swift
+++ b/FitLink/Views/WorkoutSession/MetricEditorView.swift
@@ -91,7 +91,15 @@ struct MetricEditorView: View {
     private func binding(for index: Int) -> Binding<ExerciseSet> {
         Binding<ExerciseSet>(
             get: { viewModel.approaches[index].sets.first ?? ExerciseSet(id: UUID(), metricValues: [:], notes: nil, drops: nil) },
-            set: { viewModel.approaches[index].sets = [$0] }
+            set: { newValue in
+                var sets = viewModel.approaches[index].sets
+                if sets.isEmpty {
+                    sets = [newValue]
+                } else {
+                    sets[0] = newValue
+                }
+                viewModel.approaches[index].sets = sets
+            }
         )
     }
 

--- a/FitLink/Views/WorkoutSession/MetricEditorView.swift
+++ b/FitLink/Views/WorkoutSession/MetricEditorView.swift
@@ -50,6 +50,9 @@ struct MetricEditorView: View {
                 }
             }
             .listStyle(.plain)
+            .simultaneousGesture(
+                TapGesture().onEnded { _ in hideKeyboard() }
+            )
             .navigationTitle(NSLocalizedString("MetricEditor.Title", comment: "Edit Sets"))
             .navigationBarTitleDisplayMode(.inline)
             .onAppear {
@@ -65,6 +68,7 @@ struct MetricEditorView: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button(NSLocalizedString("Common.Done", comment: "Done")) {
+                        hideKeyboard()
                         onComplete(viewModel.approaches)
                         dismiss()
                     }

--- a/FitLink/Views/WorkoutSession/MetricEditorView.swift
+++ b/FitLink/Views/WorkoutSession/MetricEditorView.swift
@@ -41,13 +41,17 @@ struct MetricEditorView: View {
                 .onDelete(perform: viewModel.removeApproach)
 
                 Button(action: viewModel.addApproach) {
-                    HStack {
-                        Spacer()
-                        Image(systemName: "plus")
-                        Text(NSLocalizedString("WorkoutExerciseEdit.AddSet", comment: "Add Set"))
-                        Spacer()
-                    }
+                    Image(systemName: "plus")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Theme.color.backgroundSecondary)
+                        .cornerRadius(Theme.radius.card)
                 }
+                .buttonStyle(.plain)
+                .listRowInsets(EdgeInsets(top: 0,
+                                         leading: Theme.spacing.large,
+                                         bottom: 0,
+                                         trailing: Theme.spacing.large))
             }
             .listStyle(.plain)
             .simultaneousGesture(

--- a/FitLink/Views/WorkoutSession/MetricEditorView.swift
+++ b/FitLink/Views/WorkoutSession/MetricEditorView.swift
@@ -21,9 +21,17 @@ struct MetricEditorView: View {
             List {
                 ForEach(Array(viewModel.approaches.enumerated()), id: \.offset) { idx, approach in
                     VStack(alignment: .leading, spacing: Theme.spacing.small) {
-                        Button(action: { viewModel.editDrops(for: idx) }) {
+                        HStack(spacing: Theme.spacing.small) {
                             ApproachCardView(set: approachSet(from: approach), metrics: viewModel.metrics)
                                 .frame(height: 64)
+                            Button(action: { viewModel.editDrops(for: idx) }) {
+                                Image(systemName: "plus")
+                                    .frame(width: 64, height: 64)
+                                    .foregroundColor(.primary)
+                                    .background(Theme.color.backgroundSecondary)
+                                    .cornerRadius(Theme.radius.card)
+                            }
+                            .buttonStyle(.plain)
                         }
                         SetEditorRow(set: binding(for: idx), metrics: viewModel.metrics)
                     }
@@ -43,6 +51,7 @@ struct MetricEditorView: View {
             }
             .listStyle(.plain)
             .navigationTitle(NSLocalizedString("MetricEditor.Title", comment: "Edit Sets"))
+            .navigationBarTitleDisplayMode(.inline)
             .onAppear {
                 if let idx = scrollToIndex {
                     DispatchQueue.main.async {

--- a/FitLink/Views/WorkoutSession/SetEditorRow.swift
+++ b/FitLink/Views/WorkoutSession/SetEditorRow.swift
@@ -8,7 +8,16 @@ struct SetEditorRow: View {
 
     var body: some View {
         ForEach(metrics, id: \.type) { metric in
-            MetricInputField(value: binding(for: metric.type), metric: metric, showLabel: showLabels)
+            HStack {
+                if showLabels { Text(metric.displayName) }
+                Spacer()
+                MetricInputField(
+                    value: binding(for: metric.type),
+                    prefix: metric.type == .reps ? "x" : nil,
+                    suffix: metric.type != .reps ? metric.unit?.displayName : nil,
+                    keyboardType: .decimalPad
+                )
+            }
         }
     }
 

--- a/FitLink/Views/WorkoutSession/SetEditorRow.swift
+++ b/FitLink/Views/WorkoutSession/SetEditorRow.swift
@@ -4,31 +4,24 @@ import SwiftUI
 struct SetEditorRow: View {
     @Binding var set: ExerciseSet
     let metrics: [ExerciseMetric]
-
-    private let numberFormatter: NumberFormatter = {
-        let f = NumberFormatter()
-        f.minimumFractionDigits = 0
-        f.maximumFractionDigits = 2
-        return f
-    }()
+    var showLabels: Bool = true
 
     var body: some View {
         ForEach(metrics, id: \.type) { metric in
-            HStack {
-                Text(metric.displayName)
-                Spacer()
-                TextField("0", value: binding(for: metric.type), formatter: numberFormatter)
-                    .keyboardType(.decimalPad)
-                    .multilineTextAlignment(.trailing)
-                    .foregroundColor(.primary)
-            }
+            MetricInputField(value: binding(for: metric.type), metric: metric, showLabel: showLabels)
         }
     }
 
-    private func binding(for type: ExerciseMetricType) -> Binding<Double> {
-        Binding<Double>(
-            get: { set.metricValues[type] ?? 0 },
-            set: { set.metricValues[type] = $0 }
+    private func binding(for type: ExerciseMetricType) -> Binding<Double?> {
+        Binding<Double?>(
+            get: { set.metricValues[type] },
+            set: { newValue in
+                if let value = newValue {
+                    set.metricValues[type] = value
+                } else {
+                    set.metricValues.removeValue(forKey: type)
+                }
+            }
         )
     }
 }

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 struct WorkoutSessionView: View {
     @StateObject private var viewModel: WorkoutSessionViewModel
 
-    init(session: WorkoutSession, client: Client?) {
-        _viewModel = StateObject(wrappedValue: WorkoutSessionViewModel(session: session, client: client))
+    init(session: WorkoutSession, client: Client?, store: WorkoutStore) {
+        _viewModel = StateObject(wrappedValue: WorkoutSessionViewModel(session: session, client: client, store: store))
     }
     
     var body: some View {
@@ -118,13 +118,13 @@ struct WorkoutSessionView: View {
 
 #Preview("Light") {
     NavigationStack {
-        WorkoutSessionView(session: MockData.complexMockSessions[15], client: clientsMock[0])
+        WorkoutSessionView(session: MockData.complexMockSessions[15], client: clientsMock[0], store: WorkoutStore())
     }
 }
 
 #Preview("Dark") {
     NavigationStack {
-        WorkoutSessionView(session: MockData.complexMockSessions[15], client: clientsMock[0])
+        WorkoutSessionView(session: MockData.complexMockSessions[15], client: clientsMock[0], store: WorkoutStore())
     }
     .preferredColorScheme(.dark)
 }


### PR DESCRIPTION
## Summary
- add reusable `MetricInputField` for editing metric values
- refactor `SetEditorRow` to use the new input field
- revise Metric and Drop editor UIs with inline titles and better drop button
- drop edit toolbar button and cleanup layout
- localize new short titles

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6853d691785483309bc7fdf1f16862e6