### PR TITLE
Fix deprecated onChange calls

### DIFF
--- a/FitLink/UIAtoms/WorkoutScreen/MetricInputField.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/MetricInputField.swift
@@ -43,7 +43,7 @@ struct MetricInputField: View {
                             .stroke(focused ? Theme.color.accent : Color.gray.opacity(0.3))
                     )
                     .onTapGesture { handleTap() }
-                    .onChange(of: text) { newValue in
+                    .onChange(of: text) { _, newValue in
                         text = newValue.trimLeadingZeros()
                         syncBinding()
                     }
@@ -57,7 +57,9 @@ struct MetricInputField: View {
         }
         .font(Theme.font.body.bold())
         .onAppear { text = formattedValue }
-        .onChange(of: focused) { if !$0 { commit() } }
+        .onChange(of: focused) { _, newValue in
+            if !newValue { commit() }
+        }
     }
 
     private var formattedValue: String {


### PR DESCRIPTION
## Summary
- refactor MetricInputField to use the iOS 17 onChange API

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6853e4c43f208330b9bd77576d451bc4