### PR TITLE
Fix drop row deletion indexing

### DIFF
--- a/FitLink/Views/WorkoutSession/DropSetEditorView.swift
+++ b/FitLink/Views/WorkoutSession/DropSetEditorView.swift
@@ -31,6 +31,7 @@ struct DropSetEditorView: View {
                             .font(Theme.font.caption)
                             .foregroundColor(.secondary)
                     }
+                    .deleteDisabled(idx == 0)
                 }
                 .onDelete(perform: viewModel.deleteDrops)
 

--- a/FitLink/Views/WorkoutSession/DropSetEditorViewModel.swift
+++ b/FitLink/Views/WorkoutSession/DropSetEditorViewModel.swift
@@ -18,15 +18,13 @@ final class DropSetEditorViewModel: ObservableObject {
     }
 
     func deleteDrops(at offsets: IndexSet) {
-        // Offsets correspond to visible rows. Row 0 is the main set and should
-        // be protected from deletion. Filter out attempts to delete it and
-        // remove the remaining drop rows directly.
-        let dropOffsets = IndexSet(offsets.filter { $0 > 0 })
-
-        guard !dropOffsets.isEmpty else { return }
+        // `List` supplies indexes starting from the first deletable row.
+        // Since the main set (row 0) isn't deletable, shift each index by +1
+        // to target the matching element in `sets`.
+        let actualOffsets = IndexSet(offsets.map { $0 + 1 })
 
         withAnimation {
-            sets.remove(atOffsets: dropOffsets)
+            sets.remove(atOffsets: actualOffsets)
         }
     }
 

--- a/FitLink/Views/WorkoutSession/DropSetEditorViewModel.swift
+++ b/FitLink/Views/WorkoutSession/DropSetEditorViewModel.swift
@@ -18,8 +18,20 @@ final class DropSetEditorViewModel: ObservableObject {
     }
 
     func deleteDrops(at offsets: IndexSet) {
+        // The index set we receive is based on the rows displayed in the list.
+        // Row 0 is the main set and should never be removed. Drop sets start at
+        // index 1 in `sets`. Convert the visual positions to the actual array
+        // indices and ignore attempts to delete the main set.
+        let adjustedOffsets = IndexSet(
+            offsets
+                .filter { $0 > 0 }
+                .map { $0 + 1 }
+        )
+
+        guard !adjustedOffsets.isEmpty else { return }
+
         withAnimation {
-            sets.remove(atOffsets: offsets)
+            sets.remove(atOffsets: adjustedOffsets)
         }
     }
 

--- a/FitLink/Views/WorkoutSession/DropSetEditorViewModel.swift
+++ b/FitLink/Views/WorkoutSession/DropSetEditorViewModel.swift
@@ -18,20 +18,15 @@ final class DropSetEditorViewModel: ObservableObject {
     }
 
     func deleteDrops(at offsets: IndexSet) {
-        // The index set we receive is based on the rows displayed in the list.
-        // Row 0 is the main set and should never be removed. Drop sets start at
-        // index 1 in `sets`. Convert the visual positions to the actual array
-        // indices and ignore attempts to delete the main set.
-        let adjustedOffsets = IndexSet(
-            offsets
-                .filter { $0 > 0 }
-                .map { $0 + 1 }
-        )
+        // Offsets correspond to visible rows. Row 0 is the main set and should
+        // be protected from deletion. Filter out attempts to delete it and
+        // remove the remaining drop rows directly.
+        let dropOffsets = IndexSet(offsets.filter { $0 > 0 })
 
-        guard !adjustedOffsets.isEmpty else { return }
+        guard !dropOffsets.isEmpty else { return }
 
         withAnimation {
-            sets.remove(atOffsets: adjustedOffsets)
+            sets.remove(atOffsets: dropOffsets)
         }
     }
 


### PR DESCRIPTION
## Summary
- adjust DropSetEditorViewModel.deleteDrops to translate visible row index to the underlying sets array
- prevent deleting the main set visually

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540bb7d154833082e6e17bf225ad51