### PR TITLE
Enable multi-metric editing on set tap

### DIFF
--- a/FitLink/Helpers/ExerciseMetricType+Sort.swift
+++ b/FitLink/Helpers/ExerciseMetricType+Sort.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension ExerciseMetricType {
+    /// Sort order placing repetitions first, weight second, others afterward
+    var sortIndex: Int {
+        switch self {
+        case .reps: return 0
+        case .weight: return 1
+        default: return 2
+        }
+    }
+}

--- a/FitLink/Localization/en.lproj/Localizable.strings
+++ b/FitLink/Localization/en.lproj/Localizable.strings
@@ -114,6 +114,7 @@
 "UnitType.Kilometer" = "km";
 "UnitType.Repetition" = "x";
 "UnitType.Calorie" = "kcal";
+"CustomNumberPad.RepsLabel" = "× reps";
 
 /* Muscle groups */
 "MuscleGroup.Chest" = "Thoracic";

--- a/FitLink/Localization/ru.lproj/Localizable.strings
+++ b/FitLink/Localization/ru.lproj/Localizable.strings
@@ -114,6 +114,7 @@
 "UnitType.Kilometer" = "км";
 "UnitType.Repetition" = "x";
 "UnitType.Calorie" = "ккал";
+"CustomNumberPad.RepsLabel" = "× раз";
 
 /* Muscle groups */
 "MuscleGroup.Chest" = "Грудные";

--- a/FitLink/UIAtoms/CustomNumberPadView.swift
+++ b/FitLink/UIAtoms/CustomNumberPadView.swift
@@ -16,7 +16,7 @@ struct CustomNumberPadView: View {
          values: Binding<[ExerciseMetric.ID: Double]>,
          onDone: @escaping () -> Void,
          onCancel: (() -> Void)? = nil) {
-        let sorted = metrics.sorted { lhs, rhs in
+        let sorted = metrics.sorted(by: { lhs, rhs in
             switch (lhs.type, rhs.type) {
             case (.reps, .reps): return false
             case (.reps, _): return true
@@ -26,14 +26,15 @@ struct CustomNumberPadView: View {
             case (_, .weight): return false
             default: return lhs.type.rawValue < rhs.type.rawValue
             }
-        }
+        })
         self.metrics = sorted
         self._metricValues = values
         self.onDone = onDone
         self.onCancel = onCancel
 
         let firstMetric = sorted.first!
-        let defaultUnits = Dictionary(uniqueKeysWithValues: sorted.map { ($0.id, DraftSet.defaultUnit(for: $0)) })
+        let defaultUnits: [ExerciseMetric.ID: UnitType] =
+            Dictionary(uniqueKeysWithValues: sorted.map { ($0.id, DraftSet.defaultUnit(for: $0)) })
         _selectedMetricId = State(initialValue: firstMetric.id)
         _metricUnits = State(initialValue: defaultUnits)
         let firstVal = values.wrappedValue[firstMetric.id] ?? 0

--- a/FitLink/UIAtoms/WorkoutScreen/ApproachCardView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachCardView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct ApproachCardView: View {
     let set: ExerciseSet
     let metrics: [ExerciseMetric]
-    var onMetricTap: (ExerciseSet.ID, ExerciseMetric) -> Void = { _, _ in }
+    var onTap: (ExerciseSet.ID) -> Void = { _ in }
 
     private var weightMetric: ExerciseMetric? {
         metrics.first { $0.type == .weight }
@@ -24,22 +24,19 @@ struct ApproachCardView: View {
             ForEach(drops.indices, id: \.self) { idx in
                 let drop = drops[idx]
                 VStack(spacing: 4) {
-                    if let weightMetric, let val = drop.metricValues[.weight] {
-                        Text(ExerciseMetric.formattedMetric(val, metric: weightMetric))
-                            .font(Theme.font.metrics1.bold())
-                            .foregroundColor(.primary)
-                            .onTapGesture { onMetricTap(drop.id, weightMetric) }
-                    }
                     if let repsMetric, let val = drop.metricValues[.reps] {
                         Text(ExerciseMetric.formattedMetric(val, metric: repsMetric))
+                            .font(Theme.font.metrics1.bold())
+                            .foregroundColor(.primary)
+                    }
+                    if let weightMetric, let val = drop.metricValues[.weight] {
+                        Text(ExerciseMetric.formattedMetric(val, metric: weightMetric))
                             .font(Theme.font.metrics2)
                             .foregroundColor(.primary)
-                            .onTapGesture { onMetricTap(drop.id, repsMetric) }
                     } else if let timeMetric, let val = drop.metricValues[.time] {
                         Text(ExerciseMetric.formattedMetric(val, metric: timeMetric))
                             .font(Theme.font.metrics2)
                             .foregroundColor(.primary)
-                            .onTapGesture { onMetricTap(drop.id, timeMetric) }
                     }
                 }
                 if idx < drops.count - 1 {
@@ -54,6 +51,7 @@ struct ApproachCardView: View {
         .background(Theme.color.textSecondary.opacity(0.05))
         .cornerRadius(Theme.radius.card)
         .contentShape(Rectangle())
+        .onTapGesture { onTap(set.id) }
     }
 
 }

--- a/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct ApproachListView: View {
     let sets: [ExerciseSet]
     let metrics: [ExerciseMetric]
-    var onMetricTap: (ExerciseSet.ID, ExerciseMetric) -> Void = { _, _ in }
+    var onSetTap: (ExerciseSet.ID) -> Void = { _ in }
 
     private var gridRows: [GridItem] { [GridItem(.fixed(64))] }
 
@@ -12,8 +12,8 @@ struct ApproachListView: View {
         ScrollView(.horizontal, showsIndicators: false) {
             LazyHGrid(rows: gridRows, spacing: Theme.spacing.small) {
                 ForEach(sets) { set in
-                    ApproachCardView(set: set, metrics: metrics) { id, metric in
-                        onMetricTap(id, metric)
+                    ApproachCardView(set: set, metrics: metrics) { id in
+                        onSetTap(id)
                     }
                     .frame(height: 64)
                 }

--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
@@ -5,7 +5,7 @@ struct ExerciseBlockCard: View {
     let group: SetGroup?
     let exerciseInstances: [ExerciseInstance]
     var onEdit: () -> Void = {}
-    var onMetricTap: (ExerciseInstance, ExerciseSet.ID, ExerciseMetric) -> Void = { _,_,_ in }
+    var onSetTap: (ExerciseInstance, ExerciseSet.ID) -> Void = { _,_ in }
 
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.spacing.small) {
@@ -30,8 +30,8 @@ struct ExerciseBlockCard: View {
                         return first
                     },
                     metrics: main.exercise.metrics,
-                    onMetricTap: { setId, metric in
-                        onMetricTap(main, setId, metric)
+                    onSetTap: { setId in
+                        onSetTap(main, setId)
                     }
                 )
             }

--- a/FitLink/UIAtoms/WorkoutScreen/SupersetApproachView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/SupersetApproachView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct SupersetApproachView: View {
     let index: Int
     let items: [(exercise: ExerciseInstance, approach: Approach?)]
-    var onMetricTap: (ExerciseInstance, ExerciseSet.ID, ExerciseMetric) -> Void = { _,_,_ in }
+    var onSetTap: (ExerciseInstance, ExerciseSet.ID) -> Void = { _,_ in }
 
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.spacing.small) {
@@ -22,8 +22,8 @@ struct SupersetApproachView: View {
                     ApproachListView(
                         sets: combinedSets(for: item.approach),
                         metrics: item.exercise.exercise.metrics,
-                        onMetricTap: { setId, metric in
-                            onMetricTap(item.exercise, setId, metric)
+                        onSetTap: { setId in
+                            onSetTap(item.exercise, setId)
                         }
                     )
                 }

--- a/FitLink/UIAtoms/WorkoutScreen/SupersetCell.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/SupersetCell.swift
@@ -5,7 +5,7 @@ struct SupersetCell: View {
     let group: SetGroup
     let exercises: [ExerciseInstance]
     var onEdit: () -> Void = {}
-    var onMetricTap: (ExerciseInstance, ExerciseSet.ID, ExerciseMetric) -> Void = { _,_,_ in }
+    var onSetTap: (ExerciseInstance, ExerciseSet.ID) -> Void = { _,_ in }
     var initiallyExpanded: Bool = false
 
     @State private var isExpanded: Bool
@@ -14,11 +14,11 @@ struct SupersetCell: View {
          exercises: [ExerciseInstance],
          initiallyExpanded: Bool = false,
          onEdit: @escaping () -> Void = {},
-         onMetricTap: @escaping (ExerciseInstance, ExerciseSet.ID, ExerciseMetric) -> Void = { _,_,_ in }) {
+         onSetTap: @escaping (ExerciseInstance, ExerciseSet.ID) -> Void = { _,_ in }) {
         self.group = group
         self.exercises = exercises
         self.onEdit = onEdit
-        self.onMetricTap = onMetricTap
+        self.onSetTap = onSetTap
         self.initiallyExpanded = initiallyExpanded
         _isExpanded = State(initialValue: initiallyExpanded)
     }
@@ -49,8 +49,8 @@ struct SupersetCell: View {
             if isExpanded {
                 VStack(alignment: .leading, spacing: Theme.spacing.small * 1.5) {
                     ForEach(Array(approaches.enumerated()), id: \.offset) { idx, data in
-                        SupersetApproachView(index: idx + 1, items: data) { ex, setId, metric in
-                            onMetricTap(ex, setId, metric)
+                        SupersetApproachView(index: idx + 1, items: data) { ex, setId in
+                            onSetTap(ex, setId)
                         }
                         .padding(Theme.spacing.small)
                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/FitLink/UIAtoms/WorkoutScreen/WorkoutExerciseRowView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/WorkoutExerciseRowView.swift
@@ -6,7 +6,7 @@ struct WorkoutExerciseRowView: View {
     var groupExercises: [ExerciseInstance] = []
     var onEdit: () -> Void
     var onDelete: () -> Void
-    var onMetricEdit: (ExerciseInstance, ExerciseSet.ID, ExerciseMetric) -> Void
+    var onSetEdit: (ExerciseInstance, ExerciseSet.ID) -> Void
     var initiallyExpanded: Bool = false
 
     var body: some View {
@@ -34,17 +34,17 @@ struct WorkoutExerciseRowView: View {
                              exercises: groupExercises,
                              initiallyExpanded: initiallyExpanded,
                              onEdit: onEdit,
-                             onMetricTap: { ex, setId, metric in
-                                 onMetricEdit(ex, setId, metric)
+                             onSetTap: { ex, setId in
+                                 onSetEdit(ex, setId)
                              })
             } else {
-                ExerciseBlockCard(group: group, exerciseInstances: groupExercises, onEdit: onEdit, onMetricTap: { ex, setId, metric in
-                    onMetricEdit(ex, setId, metric)
+                ExerciseBlockCard(group: group, exerciseInstances: groupExercises, onEdit: onEdit, onSetTap: { ex, setId in
+                    onSetEdit(ex, setId)
                 })
             }
         } else {
-            ExerciseBlockCard(group: nil, exerciseInstances: [exercise], onEdit: onEdit, onMetricTap: { _, setId, metric in
-                onMetricEdit(exercise, setId, metric)
+            ExerciseBlockCard(group: nil, exerciseInstances: [exercise], onEdit: onEdit, onSetTap: { _, setId in
+                onSetEdit(exercise, setId)
             })
         }
     }
@@ -57,7 +57,7 @@ struct WorkoutExerciseRowView: View {
                                   group: nil,
                                   onEdit: {},
                                   onDelete: {},
-                                  onMetricEdit: { _,_,_ in },
+                                  onSetEdit: { _,_ in },
                                   initiallyExpanded: false)
         .padding()
 }

--- a/FitLink/Views/WorkoutSession/SetEditorRow.swift
+++ b/FitLink/Views/WorkoutSession/SetEditorRow.swift
@@ -14,7 +14,7 @@ struct SetEditorRow: View {
                 Spacer()
                 MetricInputField(
                     value: binding(for: metric.type),
-                    labelPrefix: metric.type == .reps ? "×" : nil,
+                    labelPrefix: metric.type == .reps ? NSLocalizedString("CustomNumberPad.RepsLabel", comment: "× reps") : nil,
                     labelSuffix: metric.type != .reps ? metric.unit?.displayName : nil,
                     keyboardType: .decimalPad,
                     presets: presets(for: metric.type),

--- a/FitLink/Views/WorkoutSession/SetEditorRow.swift
+++ b/FitLink/Views/WorkoutSession/SetEditorRow.swift
@@ -8,7 +8,7 @@ struct SetEditorRow: View {
     var scrollProxy: ScrollViewProxy? = nil
 
     var body: some View {
-        ForEach(metrics, id: \.type) { metric in
+        ForEach(sortedMetrics, id: \.type) { metric in
             HStack {
                 if showLabels { Text(metric.displayName) }
                 Spacer()
@@ -23,6 +23,20 @@ struct SetEditorRow: View {
                 )
             } //: HStack
         } //: ForEach
+    }
+
+    private var sortedMetrics: [ExerciseMetric] {
+        metrics.sorted { lhs, rhs in
+            order(lhs.type) < order(rhs.type)
+        }
+    }
+
+    private func order(_ type: ExerciseMetricType) -> Int {
+        switch type {
+        case .reps: return 0
+        case .weight: return 1
+        default: return 2
+        }
     }
 
     private func binding(for type: ExerciseMetricType) -> Binding<String> {

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -48,17 +48,17 @@ struct WorkoutSessionView: View {
                 viewModel.completeEdit(result)
             }
         }
-        .sheet(item: $viewModel.activeMetricEdit) { context in
+        .sheet(item: $viewModel.activeSetEdit) { context in
             CustomNumberPadView(
-                value: Binding(
-                    get: { viewModel.activeMetricEdit?.currentValue ?? 0 },
-                    set: { viewModel.activeMetricEdit?.currentValue = $0 }
+                metrics: context.metrics,
+                values: Binding(
+                    get: { viewModel.activeSetEdit?.values ?? [:] },
+                    set: { viewModel.activeSetEdit?.values = $0 }
                 ),
-                unit: context.unit,
                 onDone: {
-                    viewModel.saveEditedMetric()
+                    viewModel.saveEditedSet()
                 },
-                onCancel: { viewModel.activeMetricEdit = nil }
+                onCancel: { viewModel.activeSetEdit = nil }
             )
             .presentationDetents([.fraction(0.65)])
         }
@@ -102,8 +102,8 @@ struct WorkoutSessionView: View {
                             groupExercises: groupExercises,
                             onEdit: { viewModel.editItemTapped(withId: group.id) },
                             onDelete: { viewModel.deleteItem(withId: group.id) },
-                            onMetricEdit: { ex, setId, metric in
-                                viewModel.edit(metric: metric, forSet: setId, ofExercise: ex.id)
+                            onSetEdit: { ex, setId in
+                                viewModel.editSet(withID: setId, ofExercise: ex.id)
                             },
                             initiallyExpanded: viewModel.expandedGroupId == group.id
                         )
@@ -119,8 +119,8 @@ struct WorkoutSessionView: View {
                             group: nil,
                             onEdit: { viewModel.editItemTapped(withId: ex.id) },
                             onDelete: { viewModel.deleteItem(withId: ex.id) },
-                            onMetricEdit: { ex, setId, metric in
-                                viewModel.edit(metric: metric, forSet: setId, ofExercise: ex.id)
+                            onSetEdit: { ex, setId in
+                                viewModel.editSet(withID: setId, ofExercise: ex.id)
                             }
                         )
                         .listRowSeparator(.hidden)

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -51,7 +51,7 @@ struct WorkoutSessionView: View {
         .sheet(item: $viewModel.activeSetEdit) { context in
             CustomNumberPadView(
                 metrics: context.metrics,
-                values: Binding(
+                values: Binding<[ExerciseMetric.ID: Double]>(
                     get: { viewModel.activeSetEdit?.values ?? [:] },
                     set: { viewModel.activeSetEdit?.values = $0 }
                 ),


### PR DESCRIPTION
## Summary
- tap a whole set card to open metric editor
- add segmented metric selector inside `CustomNumberPadView`
- sort metrics to show reps before weight
- update workout session view model to edit entire sets

## Testing
- `xcodebuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abd4709dc83309da7f5d1b9c39f03