### PR TITLE
Fix number pad sheet spacing

### DIFF
--- a/FitLink/AGENTS.md
+++ b/FitLink/AGENTS.md
@@ -61,6 +61,7 @@ VStack {
   **TODO:** existing code rarely uses these comments. New code should adopt them for consistency.
 
 - Keep layout minimalistic and readable. Use built‑in modifiers rather than custom ones when possible.
+- **Bottom Sheets**: Keep vertical spacing minimal and match native system sheets. Avoid stacking multiple padding modifiers and prefer safe‑area‑aware layout.
 
 ## View Structure Conventions
 

--- a/FitLink/Theme/Size.swift
+++ b/FitLink/Theme/Size.swift
@@ -6,11 +6,11 @@ enum AppSize {
     static let sheetHandleHeight: CGFloat = 4
     /// Preferred height of the custom number pad sheet.
     /// Calculated as:
-    ///  - ~50 pt for picker section and drag indicator
+    ///  - ~56 pt for picker section and drag indicator
     ///  - ~48 pt value display
     ///  - 4 rows of buttons at 44 pt each plus spacing
     ///  - ~52 pt Done button plus padding
     ///  - Remaining paddings between blocks
-    ///  = ~360 pt total
-    static let numberPadSheetHeight: CGFloat = 360
+    ///  = ~394 pt total
+    static let numberPadSheetHeight: CGFloat = 394
 }

--- a/FitLink/Theme/Size.swift
+++ b/FitLink/Theme/Size.swift
@@ -4,4 +4,13 @@ enum AppSize {
     static let numberPadButtonHeight: CGFloat = 44
     static let sheetHandleWidth: CGFloat = 40
     static let sheetHandleHeight: CGFloat = 4
+    /// Preferred height of the custom number pad sheet.
+    /// Calculated as:
+    ///  - ~50 pt for picker section and drag indicator
+    ///  - ~48 pt value display
+    ///  - 4 rows of buttons at 44 pt each plus spacing
+    ///  - ~52 pt Done button plus padding
+    ///  - Remaining paddings between blocks
+    ///  = ~360 pt total
+    static let numberPadSheetHeight: CGFloat = 360
 }

--- a/FitLink/UIAtoms/CustomNumberPadView.swift
+++ b/FitLink/UIAtoms/CustomNumberPadView.swift
@@ -132,7 +132,7 @@ struct CustomNumberPadView: View {
         }
     }
     return PreviewWrapper()
-        .presentationDetents([.height(360)])
+        .presentationDetents([.height(Theme.size.numberPadSheetHeight)])
 }
 
 

--- a/FitLink/UIAtoms/CustomNumberPadView.swift
+++ b/FitLink/UIAtoms/CustomNumberPadView.swift
@@ -28,7 +28,7 @@ struct CustomNumberPadView: View {
     }
 
     var body: some View {
-        VStack(spacing: Theme.spacing.small) {
+        VStack(spacing: Theme.spacing.small / 2) {
             topSection
             numberPad
             Button(NSLocalizedString("Common.Done", comment: "Done")) {
@@ -44,7 +44,7 @@ struct CustomNumberPadView: View {
             .cornerRadius(Theme.radius.button)
         } //: VStack
         .padding(.horizontal, Theme.spacing.small)
-        .padding(.top, Theme.spacing.sheetTopPadding)
+        .padding(.top, Theme.spacing.small)
         .padding(.bottom, Theme.spacing.sheetBottomPadding)
         .background(Theme.color.background)
         .cornerRadius(Theme.radius.card)
@@ -58,16 +58,6 @@ struct CustomNumberPadView: View {
 
     private var topSection: some View {
         VStack(spacing: Theme.spacing.small) {
-            HStack {
-                Spacer()
-                RoundedRectangle(cornerRadius: 2)
-                    .fill(Color.secondary.opacity(0.4))
-                    .frame(width: Theme.size.sheetHandleWidth, height: Theme.size.sheetHandleHeight)
-                Spacer()
-            } //: HStack
-            .padding(.top, Theme.spacing.sheetTopPadding)
-            .padding(.bottom, 2)
- 
             Picker("", selection: metricSelection) {
                 ForEach(viewModel.metrics, id: \.id) { metric in
                     Text(metric.displayName).tag(metric.id)

--- a/FitLink/UIAtoms/CustomNumberPadView.swift
+++ b/FitLink/UIAtoms/CustomNumberPadView.swift
@@ -31,17 +31,19 @@ struct CustomNumberPadView: View {
         VStack(spacing: Theme.spacing.small / 2) {
             topSection
             numberPad
-            Button(NSLocalizedString("Common.Done", comment: "Done")) {
+            Button(action: {
                 commit()
                 onDone()
+            }) {
+                Text(NSLocalizedString("Common.Done", comment: "Done"))
+                    .font(Theme.font.titleSmall)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(viewModel.isValid ? Theme.color.accent : Theme.color.accent.opacity(0.3))
+                    .foregroundColor(.white)
+                    .cornerRadius(Theme.radius.button)
             }
             .disabled(!viewModel.isValid)
-            .font(Theme.font.titleSmall)
-            .frame(maxWidth: .infinity)
-            .padding()
-            .background(viewModel.isValid ? Theme.color.accent : Theme.color.accent.opacity(0.3))
-            .foregroundColor(.white)
-            .cornerRadius(Theme.radius.button)
         } //: VStack
         .padding(.horizontal, Theme.spacing.small)
         .padding(.top, Theme.spacing.small)
@@ -131,6 +133,8 @@ struct CustomNumberPadView: View {
             CustomNumberPadView(metrics: metrics, values: $values, onDone: {})
         }
     }
+    // Preview uses the fixed height detent (~394 pt) to mimic the real sheet.
+    // Switch to `.fraction(0.52)` if testing on extremely small devices.
     return PreviewWrapper()
         .presentationDetents([.height(Theme.size.numberPadSheetHeight)])
 }

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -60,6 +60,7 @@ struct WorkoutSessionView: View {
                 }
             )
             .presentationDetents([.fraction(0.65)])
+            .presentationDragIndicator(.visible)
         }
     }
 

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -60,8 +60,8 @@ struct WorkoutSessionView: View {
                 }
             )
             // Use a fixed height so the sheet hugs the content like the system
-            // calculator (~360 pt by default). On very small screens consider
-            // `.fraction(0.4)` instead.
+            // calculator (~394 pt). On very small screens consider
+            // `.fraction(0.52)` instead.
             .presentationDetents([.height(Theme.size.numberPadSheetHeight)])
             .presentationDragIndicator(.visible)
         }

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -59,7 +59,10 @@ struct WorkoutSessionView: View {
                     viewModel.saveEditedSet()
                 }
             )
-            .presentationDetents([.fraction(0.65)])
+            // Use a fixed height so the sheet hugs the content like the system
+            // calculator (~360 pt by default). On very small screens consider
+            // `.fraction(0.4)` instead.
+            .presentationDetents([.height(Theme.size.numberPadSheetHeight)])
             .presentationDragIndicator(.visible)
         }
     }


### PR DESCRIPTION
## Summary
- slim down number pad sheet layout
- rely on system drag indicator in workout session sheet
- document bottom sheet spacing convention in `AGENTS.md`

## Testing
- `swift --version`
- `swiftc -sdk $(xcrun --sdk macosx --show-sdk-path 2>/dev/null || echo '') -target x86_64-apple-macosx10.15 -o /tmp/test FitLink/UIAtoms/CustomNumberPadView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685adcc2b3dc833089cc3505d2231f11