### PR TITLE
Add set append button and display zero metrics

### DIFF
--- a/FitLink/UIAtoms/MetricInputField.swift
+++ b/FitLink/UIAtoms/MetricInputField.swift
@@ -112,7 +112,6 @@ struct MetricInputField: View {
 
     private func commit() {
         value = value.trimLeadingZeros()
-        if value == "0" { value = "" }
         if !value.isEmpty {
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
         }

--- a/FitLink/UIAtoms/WorkoutScreen/ApproachCardView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachCardView.swift
@@ -24,16 +24,19 @@ struct ApproachCardView: View {
             ForEach(drops.indices, id: \.self) { idx in
                 let drop = drops[idx]
                 VStack(spacing: 4) {
-                    if let repsMetric, let val = drop.metricValues[.reps] {
+                    if let repsMetric {
+                        let val = drop.metricValues[.reps] ?? 0
                         Text(ExerciseMetric.formattedMetric(val, metric: repsMetric))
                             .font(Theme.font.metrics1.bold())
                             .foregroundColor(.primary)
                     }
-                    if let weightMetric, let val = drop.metricValues[.weight] {
+                    if let weightMetric {
+                        let val = drop.metricValues[.weight] ?? 0
                         Text(ExerciseMetric.formattedMetric(val, metric: weightMetric))
                             .font(Theme.font.metrics2)
                             .foregroundColor(.primary)
-                    } else if let timeMetric, let val = drop.metricValues[.time] {
+                    } else if let timeMetric {
+                        let val = drop.metricValues[.time] ?? 0
                         Text(ExerciseMetric.formattedMetric(val, metric: timeMetric))
                             .font(Theme.font.metrics2)
                             .foregroundColor(.primary)

--- a/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
@@ -5,6 +5,8 @@ struct ApproachListView: View {
     let sets: [ExerciseSet]
     let metrics: [ExerciseMetric]
     var onSetTap: (ExerciseSet.ID) -> Void = { _ in }
+    var onAddTap: () -> Void = {}
+    var isLocked: Bool = false
 
     private var gridRows: [GridItem] { [GridItem(.fixed(64))] }
 
@@ -17,9 +19,38 @@ struct ApproachListView: View {
                     }
                     .frame(height: 64)
                 }
+                if !isLocked {
+                    AddSetButton(action: onAddTap)
+                        .frame(height: 64)
+                }
             }
             .padding(.vertical, Theme.spacing.small)
         } //: ScrollView
+    }
+}
+
+private struct AddSetButton: View {
+    var action: () -> Void = {}
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "plus")
+                .font(.title2)
+                .frame(minWidth: 64, maxHeight: .infinity)
+        }
+        .buttonStyle(ScaleButtonStyle())
+        .foregroundColor(.secondary)
+        .background(Theme.color.textSecondary.opacity(0.1))
+        .cornerRadius(Theme.radius.card)
+        .accessibilityLabel(NSLocalizedString("WorkoutExerciseEdit.AddSet", comment: "Add Set"))
+    }
+}
+
+private struct ScaleButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.95 : 1)
+            .opacity(configuration.isPressed ? 0.6 : 1)
     }
 }
 
@@ -32,6 +63,10 @@ struct ApproachListView: View {
     let set4 = ExerciseSet(id: UUID(), metricValues: [.weight: 50, .reps: 8], notes: nil, drops: nil)
     let set5 = ExerciseSet(id: UUID(), metricValues: [.weight: 50, .reps: 8], notes: nil, drops: nil)
     let set6 = ExerciseSet(id: UUID(), metricValues: [.weight: 50, .reps: 8], notes: nil, drops: nil)
-    return ApproachListView(sets: [set1, set2, set3, set4, set5, set6], metrics: metrics)
+    return ApproachListView(sets: [set1, set2, set3, set4, set5, set6],
+                            metrics: metrics,
+                            onSetTap: { _ in },
+                            onAddTap: {},
+                            isLocked: false)
         .padding()
 }

--- a/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
@@ -21,7 +21,7 @@ struct ApproachListView: View {
                 }
                 if !isLocked {
                     AddSetButton(action: onAddTap)
-                        .frame(height: 64)
+                        .frame(width: 64, height: 64)
                 }
             }
             .padding(.vertical, Theme.spacing.small)
@@ -36,7 +36,7 @@ private struct AddSetButton: View {
         Button(action: action) {
             Image(systemName: "plus")
                 .font(.title2)
-                .frame(minWidth: 64, maxHeight: .infinity)
+                .frame(width: 64, height: 64)
         }
         .buttonStyle(ScaleButtonStyle())
         .foregroundColor(.secondary)

--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
@@ -6,6 +6,8 @@ struct ExerciseBlockCard: View {
     let exerciseInstances: [ExerciseInstance]
     var onEdit: () -> Void = {}
     var onSetTap: (ExerciseInstance, ExerciseSet.ID) -> Void = { _,_ in }
+    var onAddSet: (ExerciseInstance) -> Void = { _ in }
+    var isLocked: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.spacing.small) {
@@ -32,7 +34,11 @@ struct ExerciseBlockCard: View {
                     metrics: main.exercise.metrics,
                     onSetTap: { setId in
                         onSetTap(main, setId)
-                    }
+                    },
+                    onAddTap: {
+                        onAddSet(main)
+                    },
+                    isLocked: isLocked
                 )
             }
         }
@@ -95,5 +101,5 @@ struct ExerciseBlockCard: View {
                 ]
             )
         ]
-    )
+        , onAddSet: { _ in }, isLocked: false)
 }

--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseSetMetricsView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseSetMetricsView.swift
@@ -56,14 +56,17 @@ struct ExerciseSetMetricsView: View {
     
     private func weightString(for set: ExerciseSet) -> String {
         guard let weightMetric else { return "" }
-        return set.metricValues[.weight].map { ExerciseMetric.formattedMetric($0, metric: weightMetric) } ?? ""
+        let value = set.metricValues[.weight] ?? 0
+        return ExerciseMetric.formattedMetric(value, metric: weightMetric)
     }
     
     private func metricString(for set: ExerciseSet) -> String {
-        if let repsMetric, let value = set.metricValues[.reps] {
+        if let repsMetric {
+            let value = set.metricValues[.reps] ?? 0
             return ExerciseMetric.formattedMetric(value, metric: repsMetric)
         }
-        if let timeMetric, let value = set.metricValues[.time] {
+        if let timeMetric {
+            let value = set.metricValues[.time] ?? 0
             return ExerciseMetric.formattedMetric(value, metric: timeMetric)
         }
         return ""

--- a/FitLink/UIAtoms/WorkoutScreen/SupersetApproachView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/SupersetApproachView.swift
@@ -5,6 +5,8 @@ struct SupersetApproachView: View {
     let index: Int
     let items: [(exercise: ExerciseInstance, approach: Approach?)]
     var onSetTap: (ExerciseInstance, ExerciseSet.ID) -> Void = { _,_ in }
+    var onAddSet: (ExerciseInstance) -> Void = { _ in }
+    var isLocked: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.spacing.small) {
@@ -24,7 +26,11 @@ struct SupersetApproachView: View {
                         metrics: item.exercise.exercise.metrics,
                         onSetTap: { setId in
                             onSetTap(item.exercise, setId)
-                        }
+                        },
+                        onAddTap: {
+                            onAddSet(item.exercise)
+                        },
+                        isLocked: isLocked
                     )
                 }
             }
@@ -43,5 +49,9 @@ struct SupersetApproachView: View {
     let metrics = [ExerciseMetric(type: .reps, unit: .repetition, isRequired: true),
                    ExerciseMetric(type: .weight, unit: .kilogram, isRequired: false)]
     let ex = ExerciseInstance(id: UUID(), exercise: Exercise(id: UUID(), name: "Test", variations: [], muscleGroups: [.chest], metrics: metrics), approaches: [], groupId: nil, notes: nil)
-    return SupersetApproachView(index: 1, items: [(ex, nil)])
+    return SupersetApproachView(index: 1,
+                                items: [(ex, nil)],
+                                onSetTap: { _,_ in },
+                                onAddSet: { _ in },
+                                isLocked: false)
 }

--- a/FitLink/UIAtoms/WorkoutScreen/SupersetCell.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/SupersetCell.swift
@@ -6,7 +6,9 @@ struct SupersetCell: View {
     let exercises: [ExerciseInstance]
     var onEdit: () -> Void = {}
     var onSetTap: (ExerciseInstance, ExerciseSet.ID) -> Void = { _,_ in }
+    var onAddSet: (ExerciseInstance) -> Void = { _ in }
     var initiallyExpanded: Bool = false
+    var isLocked: Bool = false
 
     @State private var isExpanded: Bool
 
@@ -14,12 +16,16 @@ struct SupersetCell: View {
          exercises: [ExerciseInstance],
          initiallyExpanded: Bool = false,
          onEdit: @escaping () -> Void = {},
-         onSetTap: @escaping (ExerciseInstance, ExerciseSet.ID) -> Void = { _,_ in }) {
+         onSetTap: @escaping (ExerciseInstance, ExerciseSet.ID) -> Void = { _,_ in },
+         onAddSet: @escaping (ExerciseInstance) -> Void = { _ in },
+         isLocked: Bool = false) {
         self.group = group
         self.exercises = exercises
         self.onEdit = onEdit
         self.onSetTap = onSetTap
+        self.onAddSet = onAddSet
         self.initiallyExpanded = initiallyExpanded
+        self.isLocked = isLocked
         _isExpanded = State(initialValue: initiallyExpanded)
     }
 
@@ -49,9 +55,11 @@ struct SupersetCell: View {
             if isExpanded {
                 VStack(alignment: .leading, spacing: Theme.spacing.small * 1.5) {
                     ForEach(Array(approaches.enumerated()), id: \.offset) { idx, data in
-                        SupersetApproachView(index: idx + 1, items: data) { ex, setId in
+                        SupersetApproachView(index: idx + 1, items: data, onSetTap: { ex, setId in
                             onSetTap(ex, setId)
-                        }
+                        }, onAddSet: { ex in
+                            onAddSet(ex)
+                        }, isLocked: isLocked)
                         .padding(Theme.spacing.small)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .background(

--- a/FitLink/UIAtoms/WorkoutScreen/WorkoutExerciseRowView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/WorkoutExerciseRowView.swift
@@ -7,6 +7,8 @@ struct WorkoutExerciseRowView: View {
     var onEdit: () -> Void
     var onDelete: () -> Void
     var onSetEdit: (ExerciseInstance, ExerciseSet.ID) -> Void
+    var onAddSet: (ExerciseInstance) -> Void = { _ in }
+    var isLocked: Bool = false
     var initiallyExpanded: Bool = false
 
     var body: some View {
@@ -32,20 +34,38 @@ struct WorkoutExerciseRowView: View {
             if group.type == .superset {
                 SupersetCell(group: group,
                              exercises: groupExercises,
-                             initiallyExpanded: initiallyExpanded,
                              onEdit: onEdit,
                              onSetTap: { ex, setId in
                                  onSetEdit(ex, setId)
-                             })
+                             },
+                             onAddSet: { ex in
+                                 onAddSet(ex)
+                             },
+                             initiallyExpanded: initiallyExpanded,
+                             isLocked: isLocked)
             } else {
-                ExerciseBlockCard(group: group, exerciseInstances: groupExercises, onEdit: onEdit, onSetTap: { ex, setId in
-                    onSetEdit(ex, setId)
-                })
+                ExerciseBlockCard(group: group,
+                                  exerciseInstances: groupExercises,
+                                  onEdit: onEdit,
+                                  onSetTap: { ex, setId in
+                                      onSetEdit(ex, setId)
+                                  },
+                                  onAddSet: { ex in
+                                      onAddSet(ex)
+                                  },
+                                  isLocked: isLocked)
             }
         } else {
-            ExerciseBlockCard(group: nil, exerciseInstances: [exercise], onEdit: onEdit, onSetTap: { _, setId in
-                onSetEdit(exercise, setId)
-            })
+            ExerciseBlockCard(group: nil,
+                              exerciseInstances: [exercise],
+                              onEdit: onEdit,
+                              onSetTap: { _, setId in
+                                  onSetEdit(exercise, setId)
+                              },
+                              onAddSet: { _ in
+                                  onAddSet(exercise)
+                              },
+                              isLocked: isLocked)
         }
     }
 }
@@ -58,6 +78,8 @@ struct WorkoutExerciseRowView: View {
                                   onEdit: {},
                                   onDelete: {},
                                   onSetEdit: { _,_ in },
+                                  onAddSet: { _ in },
+                                  isLocked: false,
                                   initiallyExpanded: false)
         .padding()
 }

--- a/FitLink/UIAtoms/WorkoutScreen/WorkoutExerciseRowView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/WorkoutExerciseRowView.swift
@@ -34,6 +34,7 @@ struct WorkoutExerciseRowView: View {
             if group.type == .superset {
                 SupersetCell(group: group,
                              exercises: groupExercises,
+                             initiallyExpanded: initiallyExpanded,
                              onEdit: onEdit,
                              onSetTap: { ex, setId in
                                  onSetEdit(ex, setId)
@@ -41,7 +42,6 @@ struct WorkoutExerciseRowView: View {
                              onAddSet: { ex in
                                  onAddSet(ex)
                              },
-                             initiallyExpanded: initiallyExpanded,
                              isLocked: isLocked)
             } else {
                 ExerciseBlockCard(group: group,

--- a/FitLink/Views/WorkoutSession/SetEditorRow.swift
+++ b/FitLink/Views/WorkoutSession/SetEditorRow.swift
@@ -51,7 +51,7 @@ struct SetEditorRow: View {
             },
             set: { newValue in
                 let cleaned = newValue.trimLeadingZeros()
-                if let number = Double(cleaned), number != 0 {
+                if let number = Double(cleaned) {
                     set.metricValues[type] = number
                 } else {
                     set.metricValues.removeValue(forKey: type)

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -108,6 +108,10 @@ struct WorkoutSessionView: View {
                             onSetEdit: { ex, setId in
                                 viewModel.editSet(withID: setId, ofExercise: ex.id)
                             },
+                            onAddSet: { ex in
+                                viewModel.addSet(toExercise: ex.id)
+                            },
+                            isLocked: viewModel.session.status == .completed || viewModel.session.status == .cancelled,
                             initiallyExpanded: viewModel.expandedGroupId == group.id
                         )
                         .onAppear {
@@ -124,7 +128,11 @@ struct WorkoutSessionView: View {
                             onDelete: { viewModel.deleteItem(withId: ex.id) },
                             onSetEdit: { ex, setId in
                                 viewModel.editSet(withID: setId, ofExercise: ex.id)
-                            }
+                            },
+                            onAddSet: { ex in
+                                viewModel.addSet(toExercise: ex.id)
+                            },
+                            isLocked: viewModel.session.status == .completed || viewModel.session.status == .cancelled
                         )
                         .listRowSeparator(.hidden)
                     }


### PR DESCRIPTION
## Summary
- implement gray `+` button after set list
- support tapping the button to add a new set
- keep zero metric values and display them correctly
- hide add button when session is locked/completed

## Testing
- `swift build -c release` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685ae647e9b48330a66fd14996a8c135