### PR TITLE
Add compact workout UI mode

### DIFF
--- a/FitLink/Theme/Radius.swift
+++ b/FitLink/Theme/Radius.swift
@@ -4,4 +4,7 @@ enum AppRadius {
     static let card: CGFloat = 16
     static let button: CGFloat = 16
     static let image: CGFloat = 8
+
+    /// Radius used for small pills in compact mode.
+    static let compact: CGFloat = 8
 }

--- a/FitLink/Theme/Spacing.swift
+++ b/FitLink/Theme/Spacing.swift
@@ -7,4 +7,10 @@ enum AppSpacing {
     static let extraLarge: CGFloat = 32
     static let sheetTopPadding: CGFloat = 4
     static let sheetBottomPadding: CGFloat = 4
+
+    /// Padding used when compact UI mode is enabled.
+    static let compactPadding: CGFloat = 8
+
+    /// Spacing between UI elements in compact mode.
+    static let compactInnerSpacing: CGFloat = 4
 }

--- a/FitLink/Theme/Theme.swift
+++ b/FitLink/Theme/Theme.swift
@@ -7,4 +7,7 @@ enum Theme {
     static let radius = AppRadius.self
     static let shadow = AppShadows.self
     static let size = AppSize.self
+
+    /// Flag controlling the compact UI mode.
+    static var isCompactUIEnabled: Bool = true
 }

--- a/FitLink/Theme/Typography.swift
+++ b/FitLink/Theme/Typography.swift
@@ -10,4 +10,10 @@ enum AppTypography {
     static let metadata = Font.system(size: 12, weight: .light)
     static let metrics1 = Font.system(size: 16, weight: .bold)
     static let metrics2 = Font.system(size: 16, weight: .semibold)
+
+    /// Metric font used in compact mode.
+    static let compactMetric = Font.system(size: 14, weight: .semibold)
+
+    /// Section header font for compact mode.
+    static let compactSectionHeader = Font.system(size: 14, weight: .medium)
 }

--- a/FitLink/UIAtoms/WorkoutScreen/ApproachCardView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachCardView.swift
@@ -19,26 +19,29 @@ struct ApproachCardView: View {
     }
 
     var body: some View {
-        HStack(spacing: 4) {
+        let innerSpacing = Theme.isCompactUIEnabled ? Theme.spacing.compactInnerSpacing : 4
+        let outerPadding = Theme.isCompactUIEnabled ? Theme.spacing.compactPadding : Theme.spacing.small
+        let corner = Theme.isCompactUIEnabled ? Theme.radius.compact : Theme.radius.card
+        HStack(spacing: innerSpacing) {
             let drops = [set] + (set.drops ?? [])
             ForEach(drops.indices, id: \.self) { idx in
                 let drop = drops[idx]
-                VStack(spacing: 4) {
+                VStack(spacing: innerSpacing) {
                     if let repsMetric {
                         let val = drop.metricValues[.reps] ?? 0
                         Text(ExerciseMetric.formattedMetric(val, metric: repsMetric))
-                            .font(Theme.font.metrics1.bold())
+                            .font(Theme.isCompactUIEnabled ? Theme.font.compactMetric.bold() : Theme.font.metrics1.bold())
                             .foregroundColor(.primary)
                     }
                     if let weightMetric {
                         let val = drop.metricValues[.weight] ?? 0
                         Text(ExerciseMetric.formattedMetric(val, metric: weightMetric))
-                            .font(Theme.font.metrics2)
+                            .font(Theme.isCompactUIEnabled ? Theme.font.compactMetric : Theme.font.metrics2)
                             .foregroundColor(.primary)
                     } else if let timeMetric {
                         let val = drop.metricValues[.time] ?? 0
                         Text(ExerciseMetric.formattedMetric(val, metric: timeMetric))
-                            .font(Theme.font.metrics2)
+                            .font(Theme.isCompactUIEnabled ? Theme.font.compactMetric : Theme.font.metrics2)
                             .foregroundColor(.primary)
                     }
                 }
@@ -49,10 +52,10 @@ struct ApproachCardView: View {
                 }
             }
         }
-        .padding(Theme.spacing.small)
+        .padding(outerPadding)
         .frame(minWidth: 64, maxHeight: .infinity)
         .background(Theme.color.textSecondary.opacity(0.05))
-        .cornerRadius(Theme.radius.card)
+        .cornerRadius(corner)
         .contentShape(Rectangle())
         .onTapGesture { onTap(set.id) }
     }

--- a/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
@@ -11,8 +11,10 @@ struct ApproachListView: View {
     private var gridRows: [GridItem] { [GridItem(.fixed(64))] }
 
     var body: some View {
+        let innerSpacing = Theme.isCompactUIEnabled ? Theme.spacing.compactInnerSpacing : Theme.spacing.small
+        let verticalPadding = Theme.isCompactUIEnabled ? Theme.spacing.compactPadding : Theme.spacing.small
         ScrollView(.horizontal, showsIndicators: false) {
-            LazyHGrid(rows: gridRows, spacing: Theme.spacing.small) {
+            LazyHGrid(rows: gridRows, spacing: innerSpacing) {
                 ForEach(sets) { set in
                     ApproachCardView(set: set, metrics: metrics) { id in
                         onSetTap(id)
@@ -24,7 +26,7 @@ struct ApproachListView: View {
                         .frame(width: 64, height: 64)
                 }
             }
-            .padding(.vertical, Theme.spacing.small)
+            .padding(.vertical, verticalPadding)
         } //: ScrollView
     }
 }
@@ -41,7 +43,7 @@ private struct AddSetButton: View {
         .buttonStyle(ScaleButtonStyle())
         .foregroundColor(.secondary)
         .background(Theme.color.textSecondary.opacity(0.1))
-        .cornerRadius(Theme.radius.card)
+        .cornerRadius(Theme.isCompactUIEnabled ? Theme.radius.compact : Theme.radius.card)
         .accessibilityLabel(NSLocalizedString("WorkoutExerciseEdit.AddSet", comment: "Add Set"))
     }
 }

--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
@@ -10,7 +10,9 @@ struct ExerciseBlockCard: View {
     var isLocked: Bool = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Theme.spacing.small) {
+        let innerSpacing = Theme.isCompactUIEnabled ? Theme.spacing.compactInnerSpacing : Theme.spacing.small
+        let outerPadding = Theme.isCompactUIEnabled ? Theme.spacing.compactPadding : Theme.spacing.medium
+        VStack(alignment: .leading, spacing: innerSpacing) {
             if let group {
                 Text(group.type.displayName)
                     .font(Theme.font.caption)
@@ -18,7 +20,7 @@ struct ExerciseBlockCard: View {
             }
 
             Text(title)
-                .font(Theme.font.subheading)
+                .font(Theme.isCompactUIEnabled ? Theme.font.compactSectionHeader : Theme.font.subheading)
                 .lineLimit(2)
                 .truncationMode(.tail)
             
@@ -42,8 +44,8 @@ struct ExerciseBlockCard: View {
                 )
             }
         }
-        .padding(.horizontal ,Theme.spacing.medium)
-        .padding(.top, Theme.spacing.medium)
+        .padding(.horizontal , outerPadding)
+        .padding(.top, outerPadding)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Theme.color.backgroundSecondary)
         .cornerRadius(Theme.radius.card)

--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseSetMetricsView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseSetMetricsView.swift
@@ -18,30 +18,35 @@ struct ExerciseSetMetricsView: View {
     }
     
     var body: some View {
+        let dividerPadding = Theme.isCompactUIEnabled ? Theme.spacing.compactInnerSpacing : 4
+        let outerSpacing = Theme.isCompactUIEnabled ? Theme.spacing.compactInnerSpacing : Theme.spacing.medium
+        let innerSpacing = Theme.isCompactUIEnabled ? Theme.spacing.compactInnerSpacing : 6
+        let vSpacing = Theme.isCompactUIEnabled ? Theme.spacing.compactInnerSpacing / 2 : 2
+
         VStack {
             Divider()
-                .padding(.vertical, 4)
+                .padding(.vertical, dividerPadding)
             ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: Theme.spacing.medium) {
+                HStack(spacing: outerSpacing) {
                     ForEach(Array(sets.prefix(4).enumerated()), id: \.offset) { index, set in
-                        HStack(alignment: .center, spacing: 6) {
+                        HStack(alignment: .center, spacing: innerSpacing) {
                             let drops = [set] + (set.drops ?? [])
                             ForEach(drops.indices, id: \.self) { idx in
-                                VStack(spacing: 2) {
+                                VStack(spacing: vSpacing) {
                                     // Верхняя строка — вес
                                     Text(weightString(for: drops[idx]))
-                                        .font(.headline.bold())
+                                        .font(Theme.isCompactUIEnabled ? Theme.font.compactMetric.bold() : .headline.bold())
                                         .foregroundColor(.primary)
                                     // Нижняя строка — метрика
                                     Text(metricString(for: drops[idx]))
-                                        .font(.subheadline)
+                                        .font(Theme.isCompactUIEnabled ? Theme.font.compactMetric : .subheadline)
                                         .foregroundColor(.primary)
                                 }
                                 // Стрелка — если не последний дроп
                                 if idx < drops.count - 1 {
                                     Text("→")
-                                        .font(.headline.bold())
-                                        .padding(.horizontal, 2)
+                                        .font(Theme.isCompactUIEnabled ? Theme.font.compactMetric.bold() : .headline.bold())
+                                        .padding(.horizontal, Theme.isCompactUIEnabled ? Theme.spacing.compactInnerSpacing / 2 : 2)
                                 } else {
                                     Divider()
                                         .padding(.leading)

--- a/FitLink/UIAtoms/WorkoutScreen/WorkoutSectionHeaderView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/WorkoutSectionHeaderView.swift
@@ -5,7 +5,7 @@ struct WorkoutSectionHeaderView: View {
     let title: String
     var body: some View {
         Text(title)
-            .font(Theme.font.subheading)
+            .font(Theme.isCompactUIEnabled ? Theme.font.compactSectionHeader : Theme.font.subheading)
             .foregroundColor(Theme.color.textSecondary)
             .frame(maxWidth: .infinity, alignment: .leading)
     }


### PR DESCRIPTION
## Summary
- add `Theme.isCompactUIEnabled` flag
- define compact spacing, fonts and radius values
- update exercise cards and set displays to use compact parameters
- shrink section header fonts when compact mode is active

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685afc5165248330965a5dc09c26e1cf