### PR TITLE
Fix metric card layout

### DIFF
--- a/FitLink/UIAtoms/WorkoutScreen/ApproachCardView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachCardView.swift
@@ -20,9 +20,6 @@ struct ApproachCardView: View {
 
     var body: some View {
         let innerSpacing = Theme.current.layoutMode == .compact ? Theme.current.spacing.compactInnerSpacing : Theme.spacing.small / 2
-        let horizontalPadding = Theme.current.layoutMode == .compact ? Theme.current.spacing.compactMetricHorizontalPadding : Theme.spacing.small
-        let verticalPadding = Theme.current.layoutMode == .compact ? Theme.current.spacing.compactMetricVerticalPadding : Theme.spacing.small
-        let corner = Theme.current.layoutMode == .compact ? Theme.current.radius.compactSetCell : Theme.radius.card
         HStack(spacing: innerSpacing) {
             let drops = [set] + (set.drops ?? [])
             ForEach(drops.indices, id: \.self) { idx in
@@ -53,11 +50,8 @@ struct ApproachCardView: View {
                 }
             }
         }
-        .padding(.horizontal, horizontalPadding)
-        .padding(.vertical, verticalPadding)
-        .frame(minWidth: 64, maxHeight: .infinity)
-        .background(Theme.color.textSecondary.opacity(0.05))
-        .cornerRadius(corner)
+        .metricCardStyle()
+        .frame(minWidth: 64)
         .contentShape(Rectangle())
         .onTapGesture { onTap(set.id) }
     }
@@ -69,6 +63,5 @@ struct ApproachCardView: View {
                    ExerciseMetric(type: .weight, unit: .kilogram, isRequired: false)]
     let set1 = ExerciseSet(id: UUID(), metricValues: [.weight: 50, .reps: 8], notes: nil, drops: [ExerciseSet(id: UUID(), metricValues: [.weight: 40, .reps: 8], notes: nil, drops: nil)])
     return ApproachCardView(set: set1, metrics: metrics)
-        .frame(height: 64)
         .padding()
 }

--- a/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
@@ -8,14 +8,7 @@ struct ApproachListView: View {
     var onAddTap: () -> Void = {}
     var isLocked: Bool = false
 
-    private var rowHeight: CGFloat {
-        if Theme.current.layoutMode == .compact {
-            return metrics.count > 1 ? Theme.size.compactApproachMultiHeight : Theme.size.compactApproachSingleHeight
-        }
-        return Theme.size.approachCardHeight
-    }
-
-    private var gridRows: [GridItem] { [GridItem(.fixed(rowHeight))] }
+    private var gridRows: [GridItem] { [GridItem(.flexible())] }
 
     var body: some View {
         let innerSpacing = Theme.current.layoutMode == .compact ? Theme.current.spacing.compactMetricSpacing : Theme.spacing.small
@@ -26,11 +19,9 @@ struct ApproachListView: View {
                     ApproachCardView(set: set, metrics: metrics) { id in
                         onSetTap(id)
                     }
-                    .frame(height: rowHeight)
                 }
                 if !isLocked {
                     AddSetButton(action: onAddTap)
-                        .frame(width: rowHeight, height: rowHeight)
                 }
             }
             .padding(.vertical, verticalPadding)
@@ -42,18 +33,14 @@ private struct AddSetButton: View {
     var action: () -> Void = {}
 
     var body: some View {
-        let innerPaddingH = Theme.current.layoutMode == .compact ? Theme.current.spacing.compactMetricHorizontalPadding : Theme.spacing.small
-        let innerPaddingV = Theme.current.layoutMode == .compact ? Theme.current.spacing.compactMetricVerticalPadding : Theme.spacing.small
         Button(action: action) {
             Image(systemName: "plus")
                 .font(.title2)
-                .padding(.horizontal, innerPaddingH)
-                .padding(.vertical, innerPaddingV)
         }
+        .metricCardStyle()
         .buttonStyle(ScaleButtonStyle())
         .foregroundColor(.secondary)
-        .background(Theme.color.textSecondary.opacity(0.1))
-        .cornerRadius(Theme.current.layoutMode == .compact ? Theme.current.radius.compactSetCell : Theme.radius.card)
+        .frame(minWidth: 64)
         .accessibilityLabel(NSLocalizedString("WorkoutExerciseEdit.AddSet", comment: "Add Set"))
     }
 }

--- a/FitLink/UIAtoms/WorkoutScreen/MetricCardStyle.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/MetricCardStyle.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// Shared style for metric cards and the add-set button.
+struct MetricCardStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        let horizontalPadding = Theme.current.layoutMode == .compact ? Theme.current.spacing.compactMetricHorizontalPadding : Theme.spacing.small
+        let verticalPadding = Theme.current.layoutMode == .compact ? Theme.current.spacing.compactMetricVerticalPadding : Theme.spacing.small
+        let corner = Theme.current.layoutMode == .compact ? Theme.current.radius.compactSetCell : Theme.radius.card
+        content
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
+            .background(Theme.color.textSecondary.opacity(0.05))
+            .cornerRadius(corner)
+    }
+}
+
+extension View {
+    /// Applies standard styling for approach metric cards.
+    func metricCardStyle() -> some View {
+        modifier(MetricCardStyle())
+    }
+}


### PR DESCRIPTION
## Summary
- adapt `ApproachCardView` height to its content
- keep `AddSetButton` consistent with metric cards via new `MetricCardStyle`
- stop forcing explicit heights in `ApproachListView`

## Testing
- `xcodebuild -list -project FitLink.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d393674e08330b8119d3e7ce5bd44