### PR TITLE
Add developer UI mode toggle

### DIFF
--- a/FitLink/App/FitLinkApp.swift
+++ b/FitLink/App/FitLinkApp.swift
@@ -10,11 +10,13 @@ import SwiftUI
 @main
 struct FitLinkApp: App {
     @StateObject private var dataStore = AppDataStore.shared
+    @StateObject private var settings = AppSettings.shared
 
     var body: some Scene {
         WindowGroup {
             MainView()
                 .environmentObject(dataStore)
+                .environmentObject(settings)
         }
     }
 }

--- a/FitLink/CommonServices/AppSettings.swift
+++ b/FitLink/CommonServices/AppSettings.swift
@@ -1,0 +1,18 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class AppSettings: ObservableObject {
+    static let shared = AppSettings()
+
+    /// Indicates if compact UI layout should be used across the app.
+    @Published var isCompactModeEnabled: Bool = false {
+        didSet {
+            Theme.layoutMode = isCompactModeEnabled ? .compact : .regular
+        }
+    }
+
+    private init() {
+        Theme.layoutMode = isCompactModeEnabled ? .compact : .regular
+    }
+}

--- a/FitLink/Localization/en.lproj/Localizable.strings
+++ b/FitLink/Localization/en.lproj/Localizable.strings
@@ -172,3 +172,7 @@
 "Common.Done" = "Done";
 "Common.Delete" = "Delete";
 "Common.Edit" = "Edit";
+
+/* Developer settings */
+"DeveloperSettings.SectionTitle" = "Developer Settings";
+"DeveloperSettings.CompactMode" = "Compact UI Mode";

--- a/FitLink/Localization/ru.lproj/Localizable.strings
+++ b/FitLink/Localization/ru.lproj/Localizable.strings
@@ -172,3 +172,7 @@
 "Common.Done" = "Готово";
 "Common.Delete" = "Удалить";
 "Common.Edit" = "Изменить";
+
+/* Developer settings */
+"DeveloperSettings.SectionTitle" = "Настройки разработчика";
+"DeveloperSettings.CompactMode" = "Компактный интерфейс";

--- a/FitLink/Views/Profile/ProfileView.swift
+++ b/FitLink/Views/Profile/ProfileView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct ProfileView: View {
     @StateObject private var viewModel = ProfileViewModel()
+    @EnvironmentObject private var settings: AppSettings
 
     var body: some View {
         VStack {
@@ -17,6 +18,22 @@ struct ProfileView: View {
                 .imageScale(.large)
                 .foregroundStyle(.tint)
             Text(viewModel.username)
+            Spacer()
+
+#if DEBUG
+            // Developer-only settings section
+            VStack(alignment: .leading, spacing: Theme.spacing.small) {
+                Text(NSLocalizedString("DeveloperSettings.SectionTitle", comment: "Developer Settings"))
+                    .font(Theme.font.subheading)
+                    .foregroundColor(Theme.color.textSecondary)
+
+                Toggle(
+                    NSLocalizedString("DeveloperSettings.CompactMode", comment: "Compact UI Mode"),
+                    isOn: $settings.isCompactModeEnabled
+                )
+            }
+            .padding(.top, Theme.spacing.large)
+#endif
         }
         .padding()
     }
@@ -24,4 +41,5 @@ struct ProfileView: View {
 
 #Preview {
     ProfileView()
+        .environmentObject(AppSettings.shared)
 }


### PR DESCRIPTION
## Summary
- add shared `AppSettings` object to hold UI mode
- inject `AppSettings` into `FitLinkApp`
- localize developer settings strings
- show a debug-only toggle in `ProfileView`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685d5067b4ec833080955445c89b476a