### PR TITLE
Validate reps as integers

### DIFF
--- a/FitLink/Views/WorkoutSession/SetEditorRow.swift
+++ b/FitLink/Views/WorkoutSession/SetEditorRow.swift
@@ -14,6 +14,7 @@ struct SetEditorRow: View {
                 Spacer()
                 MetricInputField(
                     value: binding(for: metric.type),
+                    metricType: metric.type,
                     labelPrefix: metric.type == .reps ? NSLocalizedString("CustomNumberPad.RepsLabel", comment: "× reps") : nil,
                     labelSuffix: metric.type != .reps ? metric.unit?.displayName : nil,
                     keyboardType: .decimalPad,


### PR DESCRIPTION
## Summary
- enforce integer-only input for repetition metrics
- inject metric type into `MetricInputField`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d5e49dec48330932d4e92100d4a58