### PR TITLE
Refactor metric values to type-safe enum

### DIFF
--- a/FitLink/Models/Exercise/ExerciseMetric.swift
+++ b/FitLink/Models/Exercise/ExerciseMetric.swift
@@ -21,14 +21,12 @@ struct ExerciseMetric: Codable, Equatable, Hashable {
         type.iconName
     }
     
-    static func formattedMetric(_ value: Double, metric: ExerciseMetric) -> String {
-        let intValue = value == floor(value) ? String(Int(value)) : String(format: "%.1f", value)
-        if metric.type == .reps, let unit = metric.unit?.displayName, !unit.isEmpty {
-            return " \(unit) \(intValue)"
-        } else if let unit = metric.unit?.displayName, !unit.isEmpty {
-            return "\(intValue) \(unit)"
+    static func formattedMetric(_ value: ExerciseMetricValue, metric: ExerciseMetric) -> String {
+        let text = value.formatted
+        if let unit = metric.unit?.displayName, !unit.isEmpty {
+            return "\(text) \(unit)"
         }
-        return intValue
+        return text
     }
 }
 
@@ -113,5 +111,16 @@ enum UnitType: Codable, CaseIterable, Equatable, Hashable {
     
     static var allCases: [UnitType] {
         return [.kilogram, .pound, .second, .minute, .meter, .kilometer, .repetition, .calorie]
+    }
+}
+
+extension ExerciseMetricType {
+    var requiresInteger: Bool {
+        switch self {
+        case .reps:
+            return true
+        default:
+            return false
+        }
     }
 }

--- a/FitLink/Models/Exercise/ExerciseMetricValue.swift
+++ b/FitLink/Models/Exercise/ExerciseMetricValue.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum ExerciseMetricValue: Codable, Equatable, Hashable {
+    case int(Int)
+    case double(Double)
+
+    var doubleValue: Double {
+        switch self {
+        case .int(let value): return Double(value)
+        case .double(let value): return value
+        }
+    }
+
+    var formatted: String {
+        switch self {
+        case .int(let value):
+            return "\(value)"
+        case .double(let value):
+            return value == floor(value) ? "\(Int(value))" : String(format: "%.1f", value)
+        }
+    }
+
+    var intValue: Int? {
+        if case let .int(value) = self {
+            return value
+        }
+        return nil
+    }
+}

--- a/FitLink/Models/Workout/DraftSet.swift
+++ b/FitLink/Models/Workout/DraftSet.swift
@@ -15,7 +15,7 @@ extension ExerciseMetric {
 /// Temporary representation of an exercise set used during editing.
 struct DraftSet: Identifiable, Equatable {
     let id: UUID
-    var metricValues: [ExerciseMetric.ID: Double]
+    var metricValues: [ExerciseMetric.ID: ExerciseMetricValue]
     var metricUnits: [ExerciseMetric.ID: UnitType]
     var sourceSetID: UUID?
 }
@@ -37,17 +37,20 @@ extension DraftSet {
 
     /// Create a new draft for the provided metrics
     static func newDraft(for metrics: [ExerciseMetric]) -> DraftSet {
-        let values = Dictionary(uniqueKeysWithValues: metrics.map { ($0.id, 0.0) })
+        let values = Dictionary(uniqueKeysWithValues: metrics.map {
+            ($0.id, $0.type.requiresInteger ? .int(0) : .double(0))
+        })
         let units = Dictionary(uniqueKeysWithValues: metrics.map { ($0.id, defaultUnit(for: $0)) })
         return DraftSet(id: UUID(), metricValues: values, metricUnits: units, sourceSetID: nil)
     }
 
     /// Initialize draft from existing set and metrics
     static func from(set: ExerciseSet, metrics: [ExerciseMetric]) -> DraftSet {
-        var values: [ExerciseMetric.ID: Double] = [:]
+        var values: [ExerciseMetric.ID: ExerciseMetricValue] = [:]
         var units: [ExerciseMetric.ID: UnitType] = [:]
         for metric in metrics {
-            values[metric.id] = set.metricValues[metric.type] ?? 0.0
+            values[metric.id] = set.metricValues[metric.type] ??
+                (metric.type.requiresInteger ? .int(0) : .double(0))
             units[metric.id] = defaultUnit(for: metric)
         }
         return DraftSet(id: UUID(), metricValues: values, metricUnits: units, sourceSetID: set.id)

--- a/FitLink/Models/Workout/DraftSet.swift
+++ b/FitLink/Models/Workout/DraftSet.swift
@@ -38,7 +38,7 @@ extension DraftSet {
     /// Create a new draft for the provided metrics
     static func newDraft(for metrics: [ExerciseMetric]) -> DraftSet {
         let values = Dictionary(uniqueKeysWithValues: metrics.map {
-            ($0.id, $0.type.requiresInteger ? .int(0) : .double(0))
+            ($0.id, $0.type.requiresInteger ? ExerciseMetricValue.int(0) : ExerciseMetricValue.double(0))
         })
         let units = Dictionary(uniqueKeysWithValues: metrics.map { ($0.id, defaultUnit(for: $0)) })
         return DraftSet(id: UUID(), metricValues: values, metricUnits: units, sourceSetID: nil)

--- a/FitLink/Models/Workout/ExerciseSet.swift
+++ b/FitLink/Models/Workout/ExerciseSet.swift
@@ -10,7 +10,7 @@ import Foundation
 /// Подход
 struct ExerciseSet: Identifiable, Codable, Equatable, Hashable {
     let id: UUID
-    var metricValues: [ExerciseMetricType: Double]
+    var metricValues: [ExerciseMetricType: ExerciseMetricValue]
     var notes: String?
     var drops: [ExerciseSet]? // добавь этот массив
 }

--- a/FitLink/Stubs/ComplexSessions+Seeds.swift
+++ b/FitLink/Stubs/ComplexSessions+Seeds.swift
@@ -16,19 +16,19 @@ let dropSetApproach1 = Approach(
     sets: [
         ExerciseSet(
             id: UUID(),
-            metricValues: [.reps: 8, .weight: 50],
+            metricValues: [.reps: .int(8), .weight: .double(50)],
             notes: "Основной вес",
             drops: nil
         ),
         ExerciseSet(
             id: UUID(),
-            metricValues: [.reps: 8, .weight: 40],
+            metricValues: [.reps: .int(8), .weight: .double(40)],
             notes: "Дроп 1",
             drops: nil
         ),
         ExerciseSet(
             id: UUID(),
-            metricValues: [.reps: 8, .weight: 30],
+            metricValues: [.reps: .int(8), .weight: .double(30)],
             notes: "Дроп 2",
             drops: nil
         )
@@ -39,19 +39,19 @@ let dropSetApproach2 = Approach(
     sets: [
         ExerciseSet(
             id: UUID(),
-            metricValues: [.reps: 7, .weight: 45],
+            metricValues: [.reps: .int(7), .weight: .double(45)],
             notes: "Основной вес",
             drops: nil
         ),
         ExerciseSet(
             id: UUID(),
-            metricValues: [.reps: 7, .weight: 35],
+            metricValues: [.reps: .int(7), .weight: .double(35)],
             notes: "Дроп 1",
             drops: nil
         ),
         ExerciseSet(
             id: UUID(),
-            metricValues: [.reps: 7, .weight: 25],
+            metricValues: [.reps: .int(7), .weight: .double(25)],
             notes: "Дроп 2",
             drops: nil
         )
@@ -81,7 +81,7 @@ func generateRegularApproaches(for exercise: Exercise, reps: [Int], weights: [Do
             sets: [
                 ExerciseSet(
                     id: UUID(),
-                    metricValues: [.reps: Double(rep), .weight: weight],
+                    metricValues: [.reps: .int(rep), .weight: .double(weight)],
                     notes: nil,
                     drops: nil
                 )
@@ -113,7 +113,7 @@ func makeRegularInstance(exIndex: Int, reps: [Int], weights: [Double], section: 
             sets: [
                 ExerciseSet(
                     id: UUID(),
-                    metricValues: [.reps: Double(rep), .weight: weight],
+                    metricValues: [.reps: .int(rep), .weight: .double(weight)],
                     notes: nil,
                     drops: nil
                 )

--- a/FitLink/Stubs/SetsGenerator.swift
+++ b/FitLink/Stubs/SetsGenerator.swift
@@ -9,17 +9,17 @@ import Foundation
 
 func generateRegularApproaches(for exercise: Exercise, count: Int) -> [Approach] {
     (0..<count).map { index in
-        var metricValues: [ExerciseMetricType: Double] = [:]
+        var metricValues: [ExerciseMetricType: ExerciseMetricValue] = [:]
         for metric in exercise.metrics {
             switch metric.type {
             case .reps:
-                metricValues[.reps] = Double(8 + Int.random(in: 0...4))
+                metricValues[.reps] = .int(8 + Int.random(in: 0...4))
             case .weight:
-                metricValues[.weight] = Double(30 + 10 * index)
+                metricValues[.weight] = .double(Double(30 + 10 * index))
             case .time:
-                metricValues[.time] = Double(30 + 10 * index)
+                metricValues[.time] = .double(Double(30 + 10 * index))
             case .distance:
-                metricValues[.distance] = Double(1 + index)
+                metricValues[.distance] = .double(Double(1 + index))
             default:
                 break
             }

--- a/FitLink/UIAtoms/CustomNumberPadView.swift
+++ b/FitLink/UIAtoms/CustomNumberPadView.swift
@@ -2,14 +2,14 @@ import SwiftUI
 
 /// Bottom sheet numeric keypad for editing values of one or more metrics.
 struct CustomNumberPadView: View {
-    @Binding var metricValues: [ExerciseMetric.ID: Double]
+    @Binding var metricValues: [ExerciseMetric.ID: ExerciseMetricValue]
     var onDone: () -> Void
 
     @StateObject private var viewModel: CustomNumberPadViewModel
     
     init(
         metrics: [ExerciseMetric],
-        values: Binding<[ExerciseMetric.ID: Double]>,
+        values: Binding<[ExerciseMetric.ID: ExerciseMetricValue]>,
         onDone: @escaping () -> Void
     ) {
         self._metricValues = values
@@ -119,14 +119,19 @@ struct CustomNumberPadView: View {
     private func commit(to id: ExerciseMetric.ID? = nil) {
         let target = id ?? viewModel.selectedMetricId
         if let val = Double(viewModel.input) {
-            metricValues[target] = val
+            let metric = viewModel.metric(for: target)
+            if metric.type.requiresInteger {
+                metricValues[target] = .int(Int(val))
+            } else {
+                metricValues[target] = .double(val)
+            }
         }
     }
 }
 
 #Preview {
     struct PreviewWrapper: View {
-        @State var values: [ExerciseMetric.ID: Double] = [.reps: 8, .weight: 50]
+        @State var values: [ExerciseMetric.ID: ExerciseMetricValue] = [.reps: .int(8), .weight: .double(50)]
         let metrics = [ExerciseMetric(type: .reps, unit: .repetition, isRequired: true),
                        ExerciseMetric(type: .weight, unit: .kilogram, isRequired: false)]
         var body: some View {

--- a/FitLink/UIAtoms/CustomNumberPadView.swift
+++ b/FitLink/UIAtoms/CustomNumberPadView.swift
@@ -97,14 +97,20 @@ struct CustomNumberPadView: View {
         } //: VStack
     }
 
-    private var keys: [[String]] { [["1","2","3"],["4","5","6"],["7","8","9"],[".","0","⌫"]] }
+    private var keys: [[String]] {
+        if viewModel.currentMetric.type.requiresInteger {
+            return [["1","2","3"],["4","5","6"],["7","8","9"],["0","⌫"]]
+        } else {
+            return [["1","2","3"],["4","5","6"],["7","8","9"],[".","0","⌫"]]
+        }
+    }
 
     private func handleKey(_ key: String) {
         switch key {
         case "⌫":
             if !viewModel.input.isEmpty { viewModel.input.removeLast() }
         case ".":
-            if !viewModel.input.contains(".") {
+            if !viewModel.currentMetric.type.requiresInteger && !viewModel.input.contains(".") {
                 viewModel.input.append(viewModel.input.isEmpty ? "0." : ".")
             }
         default:

--- a/FitLink/UIAtoms/CustomNumberPadViewModel.swift
+++ b/FitLink/UIAtoms/CustomNumberPadViewModel.swift
@@ -10,7 +10,7 @@ final class CustomNumberPadViewModel: ObservableObject {
     @Published var metricUnits: [ExerciseMetric.ID: UnitType]
     @Published var selectedUnit: UnitType
 
-    init(metrics: [ExerciseMetric], values: [ExerciseMetric.ID: Double]) {
+    init(metrics: [ExerciseMetric], values: [ExerciseMetric.ID: ExerciseMetricValue]) {
         let sorted = metrics.sorted { $0.type.sortIndex < $1.type.sortIndex }
         self.metrics = sorted
         let firstMetric = sorted.first!
@@ -18,7 +18,7 @@ final class CustomNumberPadViewModel: ObservableObject {
         self.metricUnits = defaultUnits
         self.selectedMetricId = firstMetric.id
         self.selectedUnit = defaultUnits[firstMetric.id] ?? firstMetric.unit ?? .repetition
-        let firstVal = values[firstMetric.id] ?? 0
+        let firstVal = values[firstMetric.id]?.doubleValue ?? 0
         self.input = firstVal.numberPadString()
     }
 
@@ -40,11 +40,11 @@ final class CustomNumberPadViewModel: ObservableObject {
 
     var isValid: Bool { Double(input) != nil }
 
-    func updateSelection(to newID: ExerciseMetric.ID, values: [ExerciseMetric.ID: Double]) {
+    func updateSelection(to newID: ExerciseMetric.ID, values: [ExerciseMetric.ID: ExerciseMetricValue]) {
         selectedMetricId = newID
         let metric = metric(for: newID)
         selectedUnit = metricUnits[newID] ?? DraftSet.defaultUnit(for: metric)
-        let newValue = values[newID] ?? 0
+        let newValue = values[newID]?.doubleValue ?? 0
         input = newValue.numberPadString()
     }
 }

--- a/FitLink/UIAtoms/MetricInputField.swift
+++ b/FitLink/UIAtoms/MetricInputField.swift
@@ -11,6 +11,7 @@ struct MetricInputField: View {
     var presets: [Double] = []
     var scrollProxy: ScrollViewProxy? = nil
     var scrollId: AnyHashable = UUID()
+    var requiresInteger: Bool = false
     var onCommit: () -> Void = {}
 
     @State private var width: CGFloat = 0
@@ -53,7 +54,11 @@ struct MetricInputField: View {
                         .onTapGesture(count: 1) { handleTap() }
                         .onTapGesture(count: 2) { reset() }
                         .onChange(of: value) { _, newVal in
-                            value = newVal.trimLeadingZeros()
+                            if requiresInteger {
+                                value = newVal.filter { $0.isNumber }
+                            } else {
+                                value = newVal.trimLeadingZeros()
+                            }
                         }
                 }
                 .onPreferenceChange(WidthKey.self) { width = $0 }
@@ -107,7 +112,11 @@ struct MetricInputField: View {
     private func addPreset(_ preset: Double) {
         let current = Double(value) ?? 0
         let newVal = current + preset
-        value = formatValue(newVal)
+        if requiresInteger {
+            value = String(Int(newVal))
+        } else {
+            value = formatValue(newVal)
+        }
     }
 
     private func commit() {

--- a/FitLink/UIAtoms/WorkoutScreen/ApproachCardView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachCardView.swift
@@ -27,18 +27,18 @@ struct ApproachCardView: View {
                 let drop = drops[idx]
                 VStack(spacing: lineSpacing) {
                     if let repsMetric {
-                        let val = drop.metricValues[.reps] ?? 0
+                        let val = drop.metricValues[.reps] ?? .int(0)
                         Text(ExerciseMetric.formattedMetric(val, metric: repsMetric))
                             .font(Theme.current.layoutMode == .compact ? Theme.font.compactMetricValue.bold() : Theme.font.metrics1.bold())
                             .foregroundColor(.primary)
                     }
                     if let weightMetric {
-                        let val = drop.metricValues[.weight] ?? 0
+                        let val = drop.metricValues[.weight] ?? .double(0)
                         Text(ExerciseMetric.formattedMetric(val, metric: weightMetric))
                             .font(Theme.current.layoutMode == .compact ? Theme.font.compactMetricValue : Theme.font.metrics2)
                             .foregroundColor(.primary)
                     } else if let timeMetric {
-                        let val = drop.metricValues[.time] ?? 0
+                        let val = drop.metricValues[.time] ?? .double(0)
                         Text(ExerciseMetric.formattedMetric(val, metric: timeMetric))
                             .font(Theme.current.layoutMode == .compact ? Theme.font.compactMetricValue : Theme.font.metrics2)
                             .foregroundColor(.primary)
@@ -62,7 +62,7 @@ struct ApproachCardView: View {
 #Preview {
     let metrics = [ExerciseMetric(type: .reps, unit: .repetition, isRequired: true),
                    ExerciseMetric(type: .weight, unit: .kilogram, isRequired: false)]
-    let set1 = ExerciseSet(id: UUID(), metricValues: [.weight: 50, .reps: 8], notes: nil, drops: [ExerciseSet(id: UUID(), metricValues: [.weight: 40, .reps: 8], notes: nil, drops: nil)])
+    let set1 = ExerciseSet(id: UUID(), metricValues: [.weight: .double(50), .reps: .int(8)], notes: nil, drops: [ExerciseSet(id: UUID(), metricValues: [.weight: .double(40), .reps: .int(8)], notes: nil, drops: nil)])
     return ApproachCardView(set: set1, metrics: metrics)
         .padding()
 }

--- a/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
@@ -57,12 +57,12 @@ private struct ScaleButtonStyle: ButtonStyle {
 #Preview {
     let metrics = [ExerciseMetric(type: .reps, unit: .repetition, isRequired: true),
                    ExerciseMetric(type: .weight, unit: .kilogram, isRequired: false)]
-    let set1 = ExerciseSet(id: UUID(), metricValues: [.weight: 50, .reps: 8], notes: nil, drops: nil)
-    let set2 = ExerciseSet(id: UUID(), metricValues: [.weight: 50, .reps: 8], notes: nil, drops: nil)
-    let set3 = ExerciseSet(id: UUID(), metricValues: [.weight: 50, .reps: 8], notes: nil, drops: nil)
-    let set4 = ExerciseSet(id: UUID(), metricValues: [.weight: 50, .reps: 8], notes: nil, drops: nil)
-    let set5 = ExerciseSet(id: UUID(), metricValues: [.weight: 50, .reps: 8], notes: nil, drops: nil)
-    let set6 = ExerciseSet(id: UUID(), metricValues: [.weight: 50, .reps: 8], notes: nil, drops: nil)
+    let set1 = ExerciseSet(id: UUID(), metricValues: [.weight: .double(50), .reps: .int(8)], notes: nil, drops: nil)
+    let set2 = ExerciseSet(id: UUID(), metricValues: [.weight: .double(50), .reps: .int(8)], notes: nil, drops: nil)
+    let set3 = ExerciseSet(id: UUID(), metricValues: [.weight: .double(50), .reps: .int(8)], notes: nil, drops: nil)
+    let set4 = ExerciseSet(id: UUID(), metricValues: [.weight: .double(50), .reps: .int(8)], notes: nil, drops: nil)
+    let set5 = ExerciseSet(id: UUID(), metricValues: [.weight: .double(50), .reps: .int(8)], notes: nil, drops: nil)
+    let set6 = ExerciseSet(id: UUID(), metricValues: [.weight: .double(50), .reps: .int(8)], notes: nil, drops: nil)
     return ApproachListView(sets: [set1, set2, set3, set4, set5, set6],
                             metrics: metrics,
                             onSetTap: { _ in },

--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
@@ -75,8 +75,8 @@ struct ExerciseBlockCard: View {
 }
 
 #Preview {
-    let set1 = ExerciseSet(id: UUID(), metricValues: [.weight: 50, .reps: 8], notes: nil, drops: nil)
-    let set2 = ExerciseSet(id: UUID(), metricValues: [.weight: 50, .reps: 8], notes: nil, drops: nil)
+    let set1 = ExerciseSet(id: UUID(), metricValues: [.weight: .double(50), .reps: .int(8)], notes: nil, drops: nil)
+    let set2 = ExerciseSet(id: UUID(), metricValues: [.weight: .double(50), .reps: .int(8)], notes: nil, drops: nil)
     ExerciseBlockCard(
         group: .some(
             .init(id: UUID(),

--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseSetMetricsView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseSetMetricsView.swift
@@ -61,17 +61,17 @@ struct ExerciseSetMetricsView: View {
     
     private func weightString(for set: ExerciseSet) -> String {
         guard let weightMetric else { return "" }
-        let value = set.metricValues[.weight] ?? 0
+        let value = set.metricValues[.weight] ?? .double(0)
         return ExerciseMetric.formattedMetric(value, metric: weightMetric)
     }
     
     private func metricString(for set: ExerciseSet) -> String {
         if let repsMetric {
-            let value = set.metricValues[.reps] ?? 0
+            let value = set.metricValues[.reps] ?? .int(0)
             return ExerciseMetric.formattedMetric(value, metric: repsMetric)
         }
         if let timeMetric {
-            let value = set.metricValues[.time] ?? 0
+            let value = set.metricValues[.time] ?? .double(0)
             return ExerciseMetric.formattedMetric(value, metric: timeMetric)
         }
         return ""
@@ -81,8 +81,8 @@ struct ExerciseSetMetricsView: View {
 #Preview {
     let metrics = [ExerciseMetric(type: .reps, unit: .repetition, isRequired: true),
                    ExerciseMetric(type: .weight, unit: .kilogram, isRequired: false)]
-    let set1 = ExerciseSet(id: UUID(), metricValues: [.weight: 50, .reps: 8], notes: nil, drops: [ExerciseSet(id: UUID(), metricValues: [.weight: 40, .reps: 8], notes: nil, drops: nil)])
-    let set2 = ExerciseSet(id: UUID(), metricValues: [.weight: 55, .reps: 6], notes: nil, drops: nil)
+    let set1 = ExerciseSet(id: UUID(), metricValues: [.weight: .double(50), .reps: .int(8)], notes: nil, drops: [ExerciseSet(id: UUID(), metricValues: [.weight: .double(40), .reps: .int(8)], notes: nil, drops: nil)])
+    let set2 = ExerciseSet(id: UUID(), metricValues: [.weight: .double(55), .reps: .int(6)], notes: nil, drops: nil)
     return ExerciseSetMetricsView(sets: [set1, set2, set1, set2, set1, set2, set1, set2], metrics: metrics)
         .padding()
 }

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -53,7 +53,7 @@ struct WorkoutSessionView: View {
         .sheet(item: $viewModel.activeSetEdit) { context in
             CustomNumberPadView(
                 metrics: context.metrics,
-                values: Binding<[ExerciseMetric.ID: Double]>(
+                values: Binding<[ExerciseMetric.ID: ExerciseMetricValue]>(
                     get: { viewModel.activeSetEdit?.values ?? [:] },
                     set: { viewModel.activeSetEdit?.values = $0 }
                 ),


### PR DESCRIPTION
## Summary
- introduce `ExerciseMetricValue` enum
- make `ExerciseSet` and `DraftSet` store metric values using the enum
- adjust formatting helpers and input fields
- update workout views and previews
- update stub data

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_685d62819d00833097ae21697bc58fac