### PR TITLE
Support editing individual drop sets

### DIFF
--- a/FitLink/UIAtoms/WorkoutScreen/ApproachCardView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachCardView.swift
@@ -4,7 +4,8 @@ import SwiftUI
 struct ApproachCardView: View {
     let set: ExerciseSet
     let metrics: [ExerciseMetric]
-    var onTap: (ExerciseSet.ID) -> Void = { _ in }
+    var onTap: (_ setID: ExerciseSet.ID) -> Void = { _ in }
+    var onDropTap: (_ dropID: ExerciseSet.ID, _ index: Int) -> Void = { _, _ in }
 
     private var weightMetric: ExerciseMetric? {
         metrics.first { $0.type == .weight }
@@ -44,6 +45,8 @@ struct ApproachCardView: View {
                             .foregroundColor(.primary)
                     }
                 } //: VStack
+                .contentShape(Rectangle())
+                .onTapGesture { onDropTap(drop.id, idx) }
                 if idx < drops.count - 1 {
                     Image(systemName: "chevron.right")
                         .font(.caption)
@@ -63,6 +66,6 @@ struct ApproachCardView: View {
     let metrics = [ExerciseMetric(type: .reps, unit: .repetition, isRequired: true),
                    ExerciseMetric(type: .weight, unit: .kilogram, isRequired: false)]
     let set1 = ExerciseSet(id: UUID(), metricValues: [.weight: .double(50), .reps: .int(8)], notes: nil, drops: [ExerciseSet(id: UUID(), metricValues: [.weight: .double(40), .reps: .int(8)], notes: nil, drops: nil)])
-    return ApproachCardView(set: set1, metrics: metrics)
+    return ApproachCardView(set: set1, metrics: metrics, onTap: { _ in }, onDropTap: { _, _ in })
         .padding()
 }

--- a/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ApproachListView.swift
@@ -16,9 +16,11 @@ struct ApproachListView: View {
         ScrollView(.horizontal, showsIndicators: false) {
             LazyHGrid(rows: rows, spacing: innerSpacing) {
                 ForEach(sets) { set in
-                    ApproachCardView(set: set, metrics: metrics) { id in
+                    ApproachCardView(set: set, metrics: metrics, onTap: { id in
                         onSetTap(id)
-                    }
+                    }, onDropTap: { dropID, _ in
+                        onSetTap(dropID)
+                    })
                 }
                 if !isLocked {
                     AddSetButton(action: onAddTap)


### PR DESCRIPTION
## Summary
- detect taps on each drop entry in `ApproachCardView`
- forward drop tap IDs up through `ApproachListView`

## Testing
- `swiftc -emit-sil -o /tmp/out.swiftc FitLink/UIAtoms/WorkoutScreen/ApproachCardView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685e752bbea48330bf0b7a822d055f27