### PR TITLE
Add dropset creation to number pad

### DIFF
--- a/FitLink/Localization/en.lproj/Localizable.strings
+++ b/FitLink/Localization/en.lproj/Localizable.strings
@@ -115,7 +115,7 @@
 "UnitType.Repetition" = "x";
 "UnitType.Calorie" = "kcal";
 "CustomNumberPad.RepsLabel" = "reps";
-"CustomNumberPad.MainHeader" = "Main set";
+"CustomNumberPad.SetHeader" = "Main %d";
 "CustomNumberPad.DropHeader" = "Drop #%d";
 
 /* Muscle groups */

--- a/FitLink/Localization/en.lproj/Localizable.strings
+++ b/FitLink/Localization/en.lproj/Localizable.strings
@@ -115,6 +115,8 @@
 "UnitType.Repetition" = "x";
 "UnitType.Calorie" = "kcal";
 "CustomNumberPad.RepsLabel" = "reps";
+"CustomNumberPad.MainHeader" = "Main set";
+"CustomNumberPad.DropHeader" = "Drop #%d";
 
 /* Muscle groups */
 "MuscleGroup.Chest" = "Thoracic";

--- a/FitLink/Localization/ru.lproj/Localizable.strings
+++ b/FitLink/Localization/ru.lproj/Localizable.strings
@@ -115,6 +115,8 @@
 "UnitType.Repetition" = "x";
 "UnitType.Calorie" = "ккал";
 "CustomNumberPad.RepsLabel" = "";
+"CustomNumberPad.MainHeader" = "Основной сет";
+"CustomNumberPad.DropHeader" = "Дроп %d";
 
 /* Muscle groups */
 "MuscleGroup.Chest" = "Грудные";

--- a/FitLink/Localization/ru.lproj/Localizable.strings
+++ b/FitLink/Localization/ru.lproj/Localizable.strings
@@ -115,7 +115,7 @@
 "UnitType.Repetition" = "x";
 "UnitType.Calorie" = "ккал";
 "CustomNumberPad.RepsLabel" = "";
-"CustomNumberPad.MainHeader" = "Основной сет";
+"CustomNumberPad.SetHeader" = "Основной %d";
 "CustomNumberPad.DropHeader" = "Дроп %d";
 
 /* Muscle groups */

--- a/FitLink/Theme/Size.swift
+++ b/FitLink/Theme/Size.swift
@@ -12,7 +12,8 @@ enum AppSize {
     ///  - ~52 pt Done button plus padding
     ///  - Remaining paddings between blocks
     ///  = ~394 pt total
-    static let numberPadSheetHeight: CGFloat = 412
+    /// Updated to allow more vertical spacing.
+    static let numberPadSheetHeight: CGFloat = 452
 
     /// Default height for an approach card in the workout session.
     static let approachCardHeight: CGFloat = 64

--- a/FitLink/UIAtoms/CustomNumberPadView.swift
+++ b/FitLink/UIAtoms/CustomNumberPadView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 /// Bottom sheet numeric keypad for editing values of one or more metrics.
 struct CustomNumberPadView: View {
     @Binding var metricValues: [ExerciseMetric.ID: ExerciseMetricValue]
+    var headerTitle: String
+    var onAddDrop: () -> Void
     var onDone: () -> Void
 
     @StateObject private var viewModel: CustomNumberPadViewModel
@@ -10,9 +12,13 @@ struct CustomNumberPadView: View {
     init(
         metrics: [ExerciseMetric],
         values: Binding<[ExerciseMetric.ID: ExerciseMetricValue]>,
+        headerTitle: String,
+        onAddDrop: @escaping () -> Void,
         onDone: @escaping () -> Void
     ) {
         self._metricValues = values
+        self.headerTitle = headerTitle
+        self.onAddDrop = onAddDrop
         self.onDone = onDone
         _viewModel = StateObject(wrappedValue: CustomNumberPadViewModel(metrics: metrics, values: values.wrappedValue))
     }
@@ -53,6 +59,16 @@ struct CustomNumberPadView: View {
 
     private var topSection: some View {
         VStack(spacing: Theme.spacing.small) {
+            HStack {
+                Button(action: onAddDrop) {
+                    Image(systemName: "plus")
+                        .font(Theme.font.titleSmall)
+                }
+                Spacer()
+                Text(headerTitle)
+                    .font(Theme.font.titleSmall)
+            } //: HStack
+
             Picker("", selection: metricSelection) {
                 ForEach(viewModel.metrics, id: \.id) { metric in
                     Text(metric.displayName).tag(metric.id)
@@ -134,7 +150,13 @@ struct CustomNumberPadView: View {
         let metrics = [ExerciseMetric(type: .reps, unit: .repetition, isRequired: true),
                        ExerciseMetric(type: .weight, unit: .kilogram, isRequired: false)]
         var body: some View {
-            CustomNumberPadView(metrics: metrics, values: $values, onDone: {})
+            CustomNumberPadView(
+                metrics: metrics,
+                values: $values,
+                headerTitle: "Main set",
+                onAddDrop: {},
+                onDone: {}
+            )
         }
     }
     return PreviewWrapper()

--- a/FitLink/UIAtoms/CustomNumberPadView.swift
+++ b/FitLink/UIAtoms/CustomNumberPadView.swift
@@ -7,7 +7,6 @@ struct CustomNumberPadView: View {
     var onAddDrop: () -> Void
     var onDone: () -> Void
 
-    @Environment(\.safeAreaInsets) private var safeAreaInsets
 
     @StateObject private var viewModel: CustomNumberPadViewModel
     
@@ -36,27 +35,30 @@ struct CustomNumberPadView: View {
     }
 
     var body: some View {
-        VStack(spacing: Theme.spacing.small / 2) {
-            topSection
-            numberPad
-            Button(action: {
-                commit()
-                onDone()
-            }) {
-                Text(NSLocalizedString("Common.Done", comment: "Done"))
-                    .font(Theme.font.titleSmall)
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(viewModel.isValid ? Theme.color.accent : Theme.color.accent.opacity(0.3))
-                    .foregroundColor(.white)
-                    .cornerRadius(Theme.radius.button)
-            }
-            .disabled(!viewModel.isValid)
-        } //: VStack
-        .padding(.horizontal, Theme.spacing.small)
-        .padding(.top, Theme.spacing.small)
-        .padding(.bottom, Theme.spacing.sheetBottomPadding + safeAreaInsets.bottom)
-        .cornerRadius(Theme.radius.card)
+        GeometryReader { proxy in
+            VStack(spacing: Theme.spacing.small / 2) {
+                topSection
+                numberPad
+                Button(action: {
+                    commit()
+                    onDone()
+                }) {
+                    Text(NSLocalizedString("Common.Done", comment: "Done"))
+                        .font(Theme.font.titleSmall)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(viewModel.isValid ? Theme.color.accent : Theme.color.accent.opacity(0.3))
+                        .foregroundColor(.white)
+                        .cornerRadius(Theme.radius.button)
+                }
+                .disabled(!viewModel.isValid)
+            } //: VStack
+            .padding(.horizontal, Theme.spacing.small)
+            .padding(.top, Theme.spacing.small)
+            .padding(.bottom, Theme.spacing.sheetBottomPadding + proxy.safeAreaInsets.bottom)
+            .cornerRadius(Theme.radius.card)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        }
     }
 
     private var topSection: some View {

--- a/FitLink/UIAtoms/CustomNumberPadView.swift
+++ b/FitLink/UIAtoms/CustomNumberPadView.swift
@@ -7,6 +7,8 @@ struct CustomNumberPadView: View {
     var onAddDrop: () -> Void
     var onDone: () -> Void
 
+    @Environment(\.safeAreaInsets) private var safeAreaInsets
+
     @StateObject private var viewModel: CustomNumberPadViewModel
     
     init(
@@ -53,20 +55,25 @@ struct CustomNumberPadView: View {
         } //: VStack
         .padding(.horizontal, Theme.spacing.small)
         .padding(.top, Theme.spacing.small)
-        .padding(.bottom, Theme.spacing.sheetBottomPadding)
+        .padding(.bottom, Theme.spacing.sheetBottomPadding + safeAreaInsets.bottom)
         .cornerRadius(Theme.radius.card)
     }
 
     private var topSection: some View {
         VStack(spacing: Theme.spacing.small) {
             HStack {
+                Text(headerTitle)
+                    .font(Theme.font.titleSmall)
+                Spacer()
                 Button(action: onAddDrop) {
                     Image(systemName: "plus")
                         .font(Theme.font.titleSmall)
+                        .foregroundColor(Theme.color.accent)
+                        .padding(Theme.spacing.small / 2)
+                        .background(Theme.color.backgroundSecondary)
+                        .cornerRadius(Theme.radius.button)
                 }
-                Spacer()
-                Text(headerTitle)
-                    .font(Theme.font.titleSmall)
+                .buttonStyle(.plain)
             } //: HStack
 
             Picker("", selection: metricSelection) {

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -64,7 +64,7 @@ struct WorkoutSessionView: View {
                 }
             )
             // Use a fixed height so the sheet hugs the content like the system
-            // calculator (~412 pt). On very small screens consider
+            // calculator (~452 pt including safe area). On very small screens consider
             // `.fraction(0.52)` instead.
             .presentationDetents([.height(Theme.size.numberPadSheetHeight)])
             .presentationDragIndicator(.visible)

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -57,6 +57,8 @@ struct WorkoutSessionView: View {
                     get: { viewModel.activeSetEdit?.values ?? [:] },
                     set: { viewModel.activeSetEdit?.values = $0 }
                 ),
+                headerTitle: viewModel.headerTitle,
+                onAddDrop: { viewModel.addDropStep() },
                 onDone: {
                     viewModel.saveEditedSet()
                 }

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -58,7 +58,7 @@ struct WorkoutSessionView: View {
                     set: { viewModel.activeSetEdit?.values = $0 }
                 ),
                 headerTitle: viewModel.headerTitle,
-                onAddDrop: { viewModel.addDropStep() },
+                onAddSet: { viewModel.addNextSet() },
                 onDone: {
                     viewModel.saveEditedSet()
                 }

--- a/FitLink/Views/WorkoutSession/WorkoutSessionViewModel.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionViewModel.swift
@@ -115,7 +115,16 @@ final class WorkoutSessionViewModel: ObservableObject {
 
     var headerTitle: String {
         guard let context = activeSetEdit else { return "" }
-        return label(for: context.setID, in: context.exerciseID)
+        let existing = label(for: context.setID, in: context.exerciseID)
+        if !existing.isEmpty { return existing }
+
+        if let exercise = exercises.first(where: { $0.id == context.exerciseID }) {
+            return String(
+                format: NSLocalizedString("CustomNumberPad.SetHeader", comment: "Set header"),
+                exercise.approaches.count + 1
+            )
+        }
+        return ""
     }
 
     /// Saves the current editing values and immediately inserts a new drop after the current one.


### PR DESCRIPTION
## Summary
- update CustomNumberPadView with a header and add-drop button
- compute header text in WorkoutSessionViewModel
- allow adding a new drop set from the keypad
- wire up new parameters when presenting the keyboard
- localize new header strings

## Testing
- `swiftc -version`

------
https://chatgpt.com/codex/tasks/task_e_685e783c325483308ff2b86af909171f