### PR TITLE
Improve superset row deletion

### DIFF
--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -110,7 +110,9 @@ struct WorkoutSessionView: View {
                                 exercise: ex,
                                 group: group,
                                 onEdit: { viewModel.editItemTapped(withId: group.id) },
-                                onDelete: { viewModel.deleteItem(withId: group.id) },
+                                onDelete: {
+                                    viewModel.deleteExercise(ex.id, fromSuperset: group.id)
+                                },
                                 onSetEdit: { ex, setId in
                                     viewModel.editSet(withID: setId, ofExercise: ex.id)
                                 },

--- a/FitLink/Views/WorkoutSession/WorkoutSessionViewModel.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionViewModel.swift
@@ -366,6 +366,25 @@ final class WorkoutSessionViewModel: ObservableObject {
         save()
     }
 
+    /// Deletes a specific exercise from a superset. If the superset becomes
+    /// empty after the deletion, the superset itself is removed.
+    func deleteExercise(_ exerciseId: UUID, fromSuperset supersetId: UUID) {
+        guard let groupIndex = setGroups.firstIndex(where: { $0.id == supersetId }) else {
+            return
+        }
+
+        withAnimation {
+            exercises.removeAll { $0.id == exerciseId }
+            setGroups[groupIndex].exerciseInstanceIds.removeAll { $0 == exerciseId }
+
+            if setGroups[groupIndex].exerciseInstanceIds.isEmpty {
+                setGroups.remove(at: groupIndex)
+            }
+
+            save()
+        }
+    }
+
     private func save() {
         session.exerciseInstances = exercises
         session.setGroups = setGroups


### PR DESCRIPTION
## Summary
- remove individual exercises inside supersets
- clean up supersets when empty
- hook up workout view to call new ViewModel API

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_685ea28aceb88330bcbb20bda66801e4