### PR TITLE
Fix superset group title visibility

### DIFF
--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
@@ -16,7 +16,7 @@ struct ExerciseBlockCard: View {
         let innerSpacing = Theme.current.layoutMode == .compact ? Theme.current.spacing.compactInnerSpacing : Theme.spacing.small
         let outerPadding = Theme.current.layoutMode == .compact ? Theme.current.spacing.compactBlockPadding : Theme.spacing.medium
         VStack(alignment: .leading, spacing: innerSpacing) {
-            if let group, group.type != .superset {
+            if let group, shouldShowGroupTitle {
                 Text(group.type.displayName)
                     .font(Theme.font.caption)
                     .foregroundColor(Theme.color.textSecondary)
@@ -55,6 +55,16 @@ struct ExerciseBlockCard: View {
             radius: Theme.radius.card,
             corners: cornersToRound
         ))
+    }
+
+    private var shouldShowGroupTitle: Bool {
+        guard let group = group else { return false }
+        switch group.type {
+        case .superset:
+            return isFirstInGroup
+        default:
+            return true
+        }
     }
 
     private var cornersToRound: UIRectCorner {

--- a/FitLink/UIAtoms/WorkoutScreen/WorkoutExerciseRowView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/WorkoutExerciseRowView.swift
@@ -45,7 +45,7 @@ struct WorkoutExerciseRowView: View {
                               },
                               isLocked: isLocked)
         } else {
-            ExerciseBlockCard(group: nil,
+            ExerciseBlockCard(group: group?.type == .superset ? group : nil,
                               exerciseInstances: [exercise],
                               onEdit: onEdit,
                               onSetTap: { _, setId in


### PR DESCRIPTION
## Summary
- always pass `group` info to exercise card when showing a superset
- display the group title on the first card inside a superset

## Testing
- `swiftc -parse FitLink/UIAtoms/WorkoutScreen/WorkoutExerciseRowView.swift`
- `swiftc -parse FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift`

------
https://chatgpt.com/codex/tasks/task_e_685ede0806b08330bac20140dbc2103c