### PR TITLE
Add divider between superset exercises

### DIFF
--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -148,7 +148,6 @@ struct WorkoutSessionView: View {
                                 .bottom,
                                 last ? Theme.spacing.compactSetRowSpacing : Theme.spacing.extraSmall
                             )
-                            .background(!last ? Theme.color.backgroundSecondary : Color.clear)
                         } else if viewModel.isFirstExerciseInGroup(ex) {
                             let groupExercises = viewModel.groupExercises(for: group)
                             WorkoutExerciseRowView(

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -148,6 +148,7 @@ struct WorkoutSessionView: View {
                                 .bottom,
                                 last ? Theme.spacing.compactSetRowSpacing : Theme.spacing.extraSmall
                             )
+                            .background(!last ? Theme.color.backgroundSecondary : Color.clear)
                         } else if viewModel.isFirstExerciseInGroup(ex) {
                             let groupExercises = viewModel.groupExercises(for: group)
                             WorkoutExerciseRowView(

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -135,8 +135,6 @@ struct WorkoutSessionView: View {
                                 bottom: 0,
                                 trailing: 8
                             ))
-                            .padding(.top, first ? Theme.current.spacing.compactSetRowSpacing : 0)
-                            .padding(.bottom, last ? Theme.spacing.compactSetRowSpacing : 0)
                             .overlay(alignment: .bottom) {
                                 if !last {
                                     Divider()
@@ -145,6 +143,11 @@ struct WorkoutSessionView: View {
                                         .padding(.horizontal, 8)
                                 }
                             }
+                            .padding(.top, first ? Theme.current.spacing.compactSetRowSpacing : 0)
+                            .padding(
+                                .bottom,
+                                last ? Theme.spacing.compactSetRowSpacing : Theme.spacing.extraSmall
+                            )
                         } else if viewModel.isFirstExerciseInGroup(ex) {
                             let groupExercises = viewModel.groupExercises(for: group)
                             WorkoutExerciseRowView(

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -137,14 +137,13 @@ struct WorkoutSessionView: View {
                             ))
                             .padding(.top, first ? Theme.current.spacing.compactSetRowSpacing : 0)
                             .padding(.bottom, last ? Theme.spacing.compactSetRowSpacing : 0)
-
-                            if !last {
-                                Divider()
-                                    .frame(height: 1)
-                                    .background(Theme.color.border)
-                                    .padding(.horizontal, 8)
-                                    .listRowInsets(EdgeInsets())
-                                    .listRowSeparator(.hidden)
+                            .overlay(alignment: .bottom) {
+                                if !last {
+                                    Divider()
+                                        .frame(height: 1)
+                                        .background(Theme.color.border)
+                                        .padding(.horizontal, 8)
+                                }
                             }
                         } else if viewModel.isFirstExerciseInGroup(ex) {
                             let groupExercises = viewModel.groupExercises(for: group)

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -137,6 +137,15 @@ struct WorkoutSessionView: View {
                             ))
                             .padding(.top, first ? Theme.current.spacing.compactSetRowSpacing : 0)
                             .padding(.bottom, last ? Theme.spacing.compactSetRowSpacing : 0)
+
+                            if !last {
+                                Divider()
+                                    .frame(height: 1)
+                                    .background(Theme.color.border)
+                                    .padding(.horizontal, 8)
+                                    .listRowInsets(EdgeInsets())
+                                    .listRowSeparator(.hidden)
+                            }
                         } else if viewModel.isFirstExerciseInGroup(ex) {
                             let groupExercises = viewModel.groupExercises(for: group)
                             WorkoutExerciseRowView(


### PR DESCRIPTION
## Summary
- show divider for superset groups between exercise rows

## Testing
- `swiftc --version`
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee13f9c4483308c70e22e83c9b309