### PR TITLE
Implement action sheet for workout exercises

### DIFF
--- a/FitLink/Localization/en.lproj/Localizable.strings
+++ b/FitLink/Localization/en.lproj/Localizable.strings
@@ -175,6 +175,12 @@
 "Common.Delete" = "Delete";
 "Common.Edit" = "Edit";
 
+/* Workout exercise actions */
+"WorkoutExercise.Actions.History" = "History";
+"WorkoutExercise.Actions.Edit" = "Edit";
+"WorkoutExercise.Actions.Duplicate" = "Duplicate";
+"WorkoutExercise.Actions.Details" = "Details";
+
 /* Developer settings */
 "DeveloperSettings.SectionTitle" = "Developer Settings";
 "DeveloperSettings.CompactMode" = "Compact UI Mode";

--- a/FitLink/Localization/ru.lproj/Localizable.strings
+++ b/FitLink/Localization/ru.lproj/Localizable.strings
@@ -175,6 +175,12 @@
 "Common.Delete" = "Удалить";
 "Common.Edit" = "Изменить";
 
+/* Workout exercise actions */
+"WorkoutExercise.Actions.History" = "История выполнения";
+"WorkoutExercise.Actions.Edit" = "Редактировать";
+"WorkoutExercise.Actions.Duplicate" = "Дублировать";
+"WorkoutExercise.Actions.Details" = "Подробнее";
+
 /* Developer settings */
 "DeveloperSettings.SectionTitle" = "Настройки разработчика";
 "DeveloperSettings.CompactMode" = "Компактный интерфейс";

--- a/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/ExerciseBlockCard.swift
@@ -7,6 +7,7 @@ struct ExerciseBlockCard: View {
     var onEdit: () -> Void = {}
     var onSetTap: (ExerciseInstance, ExerciseSet.ID) -> Void = { _,_ in }
     var onAddSet: (ExerciseInstance) -> Void = { _ in }
+    var onMenuTap: () -> Void = {}
     var isLocked: Bool = false
     var isFirstInGroup: Bool = true
     var isLastInGroup: Bool = true
@@ -22,10 +23,23 @@ struct ExerciseBlockCard: View {
                     .foregroundColor(Theme.color.textSecondary)
             }
 
-            Text(title)
-                .font(Theme.current.layoutMode == .compact ? Theme.font.compactExerciseTitle : Theme.font.subheading)
-                .lineLimit(2)
-                .truncationMode(.tail)
+            HStack(alignment: .top) {
+                Text(title)
+                    .font(Theme.current.layoutMode == .compact ? Theme.font.compactExerciseTitle : Theme.font.subheading)
+                    .lineLimit(2)
+                    .truncationMode(.tail)
+                Spacer(minLength: Theme.spacing.small)
+                Button(action: onMenuTap) {
+                    Image(systemName: "line.3.horizontal")
+                        .padding(8)
+                        .background(Theme.color.backgroundSecondary.opacity(0.5))
+                        .clipShape(RoundedRectangle(cornerRadius: Theme.radius.button))
+                }
+                .foregroundColor(Theme.color.textSecondary)
+                .buttonStyle(.plain)
+            } //: HStack
+            .contentShape(Rectangle())
+            .onTapGesture { onMenuTap() }
 
             if let main = exerciseInstances.first {
                 ApproachListView(
@@ -125,5 +139,5 @@ struct ExerciseBlockCard: View {
                 ]
             )
         ]
-        , onAddSet: { _ in }, isLocked: false)
+        , onAddSet: { _ in }, onMenuTap: {}, isLocked: false)
 }

--- a/FitLink/UIAtoms/WorkoutScreen/WorkoutExerciseRowView.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/WorkoutExerciseRowView.swift
@@ -4,7 +4,10 @@ struct WorkoutExerciseRowView: View {
     let exercise: ExerciseInstance
     let group: SetGroup?
     var groupExercises: [ExerciseInstance] = []
+    var onHistory: () -> Void = {}
     var onEdit: () -> Void
+    var onDuplicate: () -> Void = {}
+    var onDetails: () -> Void = {}
     var onDelete: () -> Void
     var onSetEdit: (ExerciseInstance, ExerciseSet.ID) -> Void
     var onAddSet: (ExerciseInstance) -> Void = { _ in }
@@ -14,20 +17,25 @@ struct WorkoutExerciseRowView: View {
     var isLastInGroup: Bool = true
     var isGrouped: Bool = false
 
+    @State private var showActions: Bool = false
+
     var body: some View {
         ZStack {
             content
         } //: ZStack
         .contentShape(Rectangle())
         .swipeActions(allowsFullSwipe: false) {
-            Button(action: onEdit) {
-                Label(NSLocalizedString("Common.Edit", comment: "Edit"), systemImage: "gearshape")
-                    .labelStyle(.iconOnly)
-            }
             Button(role: .destructive, action: onDelete) {
                 Label(NSLocalizedString("Common.Delete", comment: "Delete"), systemImage: "trash")
                     .labelStyle(.iconOnly)
             }
+        }
+        .confirmationDialog("", isPresented: $showActions) {
+            Button(NSLocalizedString("WorkoutExercise.Actions.History", comment: "History")) { onHistory() }
+            Button(NSLocalizedString("WorkoutExercise.Actions.Edit", comment: "Edit")) { onEdit() }
+            Button(NSLocalizedString("WorkoutExercise.Actions.Duplicate", comment: "Duplicate")) { onDuplicate() }
+            Button(NSLocalizedString("WorkoutExercise.Actions.Details", comment: "Details")) { onDetails() }
+            Button(NSLocalizedString("Common.Cancel", comment: "Cancel"), role: .cancel) { }
         }
     }
 
@@ -36,24 +44,24 @@ struct WorkoutExerciseRowView: View {
         if let group, !groupExercises.isEmpty, group.type != .superset {
             ExerciseBlockCard(group: group,
                               exerciseInstances: groupExercises,
-                              onEdit: onEdit,
                               onSetTap: { ex, setId in
                                   onSetEdit(ex, setId)
                               },
                               onAddSet: { ex in
                                   onAddSet(ex)
                               },
+                              onMenuTap: { showActions = true },
                               isLocked: isLocked)
         } else {
             ExerciseBlockCard(group: group?.type == .superset ? group : nil,
                               exerciseInstances: [exercise],
-                              onEdit: onEdit,
                               onSetTap: { _, setId in
                                   onSetEdit(exercise, setId)
                               },
                               onAddSet: { _ in
                                   onAddSet(exercise)
                               },
+                              onMenuTap: { showActions = true },
                               isLocked: isLocked,
                               isFirstInGroup: isFirstInGroup,
                               isLastInGroup: isLastInGroup,
@@ -67,7 +75,10 @@ struct WorkoutExerciseRowView: View {
     let exercise = session.exerciseInstances.first!
     return WorkoutExerciseRowView(exercise: exercise,
                                   group: nil,
+                                  onHistory: {},
                                   onEdit: {},
+                                  onDuplicate: {},
+                                  onDetails: {},
                                   onDelete: {},
                                   onSetEdit: { _,_ in },
                                   onAddSet: { _ in },

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -70,6 +70,14 @@ struct WorkoutSessionView: View {
             .presentationDetents([.height(Theme.size.numberPadSheetHeight)])
             .presentationDragIndicator(.visible)
         }
+        .sheet(item: $viewModel.historyExercise) { exercise in
+            Text("History for \(exercise.exercise.name)")
+                .padding()
+        }
+        .sheet(item: $viewModel.detailExercise) { exercise in
+            Text("Details for \(exercise.exercise.name)")
+                .padding()
+        }
     }
 
     private var headerSection: some View {
@@ -109,7 +117,10 @@ struct WorkoutSessionView: View {
                             WorkoutExerciseRowView(
                                 exercise: ex,
                                 group: group,
+                                onHistory: { viewModel.showHistory(for: ex.id) },
                                 onEdit: { viewModel.editItemTapped(withId: group.id) },
+                                onDuplicate: { viewModel.duplicateItem(withId: ex.id) },
+                                onDetails: { viewModel.showDetails(for: ex.id) },
                                 onDelete: {
                                     withAnimation {
                                         viewModel.deleteExercise(ex.id, fromSuperset: group.id)
@@ -143,7 +154,10 @@ struct WorkoutSessionView: View {
                                 exercise: ex,
                                 group: group,
                                 groupExercises: groupExercises,
+                                onHistory: { viewModel.showHistory(for: group.id) },
                                 onEdit: { viewModel.editItemTapped(withId: group.id) },
+                                onDuplicate: { viewModel.duplicateItem(withId: group.id) },
+                                onDetails: { viewModel.showDetails(for: group.id) },
                                 onDelete: { viewModel.deleteItem(withId: group.id) },
                                 onSetEdit: { ex, setId in
                                     viewModel.editSet(withID: setId, ofExercise: ex.id)
@@ -172,7 +186,10 @@ struct WorkoutSessionView: View {
                         WorkoutExerciseRowView(
                             exercise: ex,
                             group: nil,
+                            onHistory: { viewModel.showHistory(for: ex.id) },
                             onEdit: { viewModel.editItemTapped(withId: ex.id) },
+                            onDuplicate: { viewModel.duplicateItem(withId: ex.id) },
+                            onDetails: { viewModel.showDetails(for: ex.id) },
                             onDelete: { viewModel.deleteItem(withId: ex.id) },
                             onSetEdit: { ex, setId in
                                 viewModel.editSet(withID: setId, ofExercise: ex.id)


### PR DESCRIPTION
## Summary
- add localized strings for exercise actions
- show a menu icon in ExerciseBlockCard and handle taps
- present confirmation dialogs in WorkoutExerciseRowView
- route new actions through WorkoutSessionViewModel
- hook up new menu features in WorkoutSessionView

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685eeb8a61d883308ced69ad40986e6a