### PR TITLE
Add workout section selector

### DIFF
--- a/FitLink/UIAtoms/WorkoutScreen/WorkoutSectionPicker.swift
+++ b/FitLink/UIAtoms/WorkoutScreen/WorkoutSectionPicker.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+/// Minimal segmented picker used to choose a workout section.
+/// Designed for dark backgrounds with a modern capsule style.
+struct WorkoutSectionPicker: View {
+    @Binding var selection: WorkoutSection
+    @Namespace private var animation
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(WorkoutSection.allCases, id: \.self) { section in
+                segment(for: section)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func segment(for section: WorkoutSection) -> some View {
+        let isSelected = selection == section
+        Button(action: { withAnimation(.easeInOut) { selection = section } }) {
+            HStack(spacing: 4) {
+                Image(systemName: iconName(for: section))
+                Text(section.displayTitle)
+            }
+            .font(Theme.font.caption.bold())
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, Theme.spacing.small)
+            .foregroundStyle(isSelected ? Color.white : Theme.color.textPrimary)
+            .background(
+                ZStack {
+                    if isSelected {
+                        RoundedRectangle(cornerRadius: Theme.radius.button)
+                            .fill(Theme.color.accent)
+                            .matchedGeometryEffect(id: "bg", in: animation)
+                    } else {
+                        RoundedRectangle(cornerRadius: Theme.radius.button)
+                            .fill(Theme.color.backgroundSecondary.opacity(0.6))
+                    }
+                }
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(section.displayName)
+    }
+
+    private func iconName(for section: WorkoutSection) -> String {
+        switch section {
+        case .warmUp: return "figure.walk" // warm-up icon
+        case .main: return "flame.fill" // main workout icon
+        case .coolDown: return "figure.cooldown" // cool-down icon
+        }
+    }
+}
+
+#if DEBUG
+struct WorkoutSectionPicker_Previews: PreviewProvider {
+    @State static var selection: WorkoutSection = .main
+    static var previews: some View {
+        WorkoutSectionPicker(selection: $selection)
+            .padding()
+            .background(Color.black)
+            .previewLayout(.sizeThatFits)
+            .preferredColorScheme(.dark)
+    }
+}
+#endif

--- a/FitLink/Views/WorkoutSession/WorkoutExerciseEditView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutExerciseEditView.swift
@@ -10,15 +10,20 @@ struct WorkoutExerciseEditView: View {
     @State private var libraryIndex: Int = 0
     @State private var showLibrary = false
 
-    init(initialExercises: [Exercise] = [], onComplete: @escaping (WorkoutExerciseEditResult) -> Void) {
+    init(initialExercises: [Exercise] = [], initialSection: WorkoutSection = .main, onComplete: @escaping (WorkoutExerciseEditResult) -> Void) {
         self.onComplete = onComplete
-        _viewModel = StateObject(wrappedValue: WorkoutExerciseEditViewModel(initialExercises: initialExercises))
+        _viewModel = StateObject(wrappedValue: WorkoutExerciseEditViewModel(initialExercises: initialExercises, section: initialSection))
         self.isEditing = !initialExercises.isEmpty
     }
 
     var body: some View {
         NavigationStack {
             List {
+                WorkoutSectionPicker(selection: $viewModel.selectedSection)
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+                    .padding(.bottom, Theme.spacing.medium)
+
                 exercisesList
             }
             .listStyle(.plain)
@@ -120,5 +125,5 @@ struct WorkoutExerciseEditView: View {
 }
 
 #Preview {
-    WorkoutExerciseEditView { _ in }
+    WorkoutExerciseEditView(initialExercises: [], initialSection: .main) { _ in }
 }

--- a/FitLink/Views/WorkoutSession/WorkoutExerciseEditViewModel.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutExerciseEditViewModel.swift
@@ -3,9 +3,12 @@ import Foundation
 @MainActor
 final class WorkoutExerciseEditViewModel: ObservableObject {
     @Published var selectedExercises: [Exercise]
+    /// Currently chosen workout section. Defaults to `.main`.
+    @Published var selectedSection: WorkoutSection
 
-    init(initialExercises: [Exercise] = []) {
+    init(initialExercises: [Exercise] = [], section: WorkoutSection = .main) {
         self.selectedExercises = initialExercises
+        self.selectedSection = section
     }
 
     var isSuperset: Bool { selectedExercises.count > 1 }
@@ -35,7 +38,7 @@ final class WorkoutExerciseEditViewModel: ObservableObject {
                 approaches: [],
                 groupId: nil,
                 notes: nil,
-                section: .main
+                section: selectedSection
             )
             return .single(instance)
         } else {
@@ -47,7 +50,7 @@ final class WorkoutExerciseEditViewModel: ObservableObject {
                     approaches: [],
                     groupId: groupId,
                     notes: nil,
-                    section: .main
+                    section: selectedSection
                 )
             }
             let group = SetGroup(

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -46,7 +46,10 @@ struct WorkoutSessionView: View {
         }
         .presentationDetents([.medium, .large])
         .sheet(isPresented: $viewModel.showExerciseEdit) {
-            WorkoutExerciseEditView(initialExercises: viewModel.editingContext?.exercises ?? []) { result in
+            WorkoutExerciseEditView(
+                initialExercises: viewModel.editingContext?.exercises ?? [],
+                initialSection: viewModel.editingContext?.instances.first?.section ?? .main
+            ) { result in
                 viewModel.completeEdit(result)
             }
         }


### PR DESCRIPTION
## Summary
- create `WorkoutSectionPicker` segmented picker for modern look
- let `WorkoutExerciseEditViewModel` store chosen section
- embed the section picker in `WorkoutExerciseEditView`
- pipe the section value into added exercises
- pass section when invoking the edit view

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_685f1e3f9f38833086df01851716aaae