### PR TITLE
Fix section persistence for workout item edits

### DIFF
--- a/FitLink/Views/WorkoutSession/WorkoutSessionViewModel.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionViewModel.swift
@@ -438,7 +438,9 @@ final class WorkoutSessionViewModel: ObservableObject {
                 instance.approaches = old.approaches
                 instance.notes = old.notes
             }
-            instance.section = context.instances.first?.section ?? .main
+            // Preserve the section chosen in the editor. Previously we always
+            // restored the old section which prevented moving an exercise
+            // between warm-up, main and cool-down when editing.
             exercises.insert(instance, at: insertionIndex)
             expandedGroupId = nil
         case .superset(var group, var instances):
@@ -451,8 +453,10 @@ final class WorkoutSessionViewModel: ObservableObject {
                         item.approaches = old.approaches
                         item.notes = old.notes
                     }
-                    item.section = old.section
                 }
+                // `item.section` already reflects the value chosen on the edit
+                // screen. Do not overwrite it with the old section so the entire
+                // superset can be moved between sections.
                 instances[i] = item
             }
             setGroups.append(group)


### PR DESCRIPTION
## Summary
- ensure edited exercises keep the selected workout section
- keep chosen section for all items when editing a superset

## Testing
- `swiftc -emit-sil -o /dev/null FitLink/Views/WorkoutSession/WorkoutSessionViewModel.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685f2a3f40d083309823fcc76707b3a8