### PR TITLE
Implement exercise detail and edit screens

### DIFF
--- a/FitLink/CommonServices/AppDataStore.swift
+++ b/FitLink/CommonServices/AppDataStore.swift
@@ -40,4 +40,12 @@ class AppDataStore: ObservableObject {
         guard let index = sessions.firstIndex(where: { $0.id == session.id }) else { return }
         sessions[index] = session
     }
+
+    func saveExercise(_ exercise: Exercise) {
+        if let index = exercises.firstIndex(where: { $0.id == exercise.id }) {
+            exercises[index] = exercise
+        } else {
+            exercises.append(exercise)
+        }
+    }
 }

--- a/FitLink/Localization/en.lproj/Localizable.strings
+++ b/FitLink/Localization/en.lproj/Localizable.strings
@@ -184,3 +184,29 @@
 /* Developer settings */
 "DeveloperSettings.SectionTitle" = "Developer Settings";
 "DeveloperSettings.CompactMode" = "Compact UI Mode";
+
+/* Exercise detail */
+"ExerciseDetail.Variations" = "Variations";
+"ExerciseDetail.Metrics" = "Metrics";
+"ExerciseDetail.MuscleGroups" = "Muscle Groups";
+"ExerciseDetail.Edit" = "Edit";
+
+/* Exercise edit */
+"ExerciseEdit.NewTitle" = "New Exercise";
+"ExerciseEdit.EditTitle" = "Edit Exercise";
+"ExerciseEdit.Name" = "Name";
+"ExerciseEdit.Description" = "Description";
+"ExerciseEdit.Media" = "Media";
+"ExerciseEdit.MediaPlaceholder" = "Select Media";
+"ExerciseEdit.Variations" = "Variations";
+"ExerciseEdit.VariationPlaceholder" = "Variation";
+"ExerciseEdit.MuscleGroups" = "Muscle Groups";
+"ExerciseEdit.MainMuscle" = "Main Muscle";
+"ExerciseEdit.Metrics" = "Metrics";
+"ExerciseEdit.MetricType" = "Type";
+"ExerciseEdit.Unit" = "Unit";
+"ExerciseEdit.Required" = "Required";
+"ExerciseEdit.AddMetric" = "Add Metric";
+
+/* Common additional */
+"Common.Save" = "Save";

--- a/FitLink/Localization/ru.lproj/Localizable.strings
+++ b/FitLink/Localization/ru.lproj/Localizable.strings
@@ -184,3 +184,29 @@
 /* Developer settings */
 "DeveloperSettings.SectionTitle" = "Настройки разработчика";
 "DeveloperSettings.CompactMode" = "Компактный интерфейс";
+
+/* Exercise detail */
+"ExerciseDetail.Variations" = "Вариации";
+"ExerciseDetail.Metrics" = "Метрики";
+"ExerciseDetail.MuscleGroups" = "Группы мышц";
+"ExerciseDetail.Edit" = "Редактировать";
+
+/* Exercise edit */
+"ExerciseEdit.NewTitle" = "Новое упражнение";
+"ExerciseEdit.EditTitle" = "Редактировать упражнение";
+"ExerciseEdit.Name" = "Название";
+"ExerciseEdit.Description" = "Описание";
+"ExerciseEdit.Media" = "Медиа";
+"ExerciseEdit.MediaPlaceholder" = "Выбрать медиа";
+"ExerciseEdit.Variations" = "Вариации";
+"ExerciseEdit.VariationPlaceholder" = "Вариация";
+"ExerciseEdit.MuscleGroups" = "Группы мышц";
+"ExerciseEdit.MainMuscle" = "Основная";
+"ExerciseEdit.Metrics" = "Метрики";
+"ExerciseEdit.MetricType" = "Тип";
+"ExerciseEdit.Unit" = "Ед.";
+"ExerciseEdit.Required" = "Обязательная";
+"ExerciseEdit.AddMetric" = "Добавить метрику";
+
+/* Common additional */
+"Common.Save" = "Сохранить";

--- a/FitLink/Models/Exercise/ExerciseMetric.swift
+++ b/FitLink/Models/Exercise/ExerciseMetric.swift
@@ -123,4 +123,34 @@ extension ExerciseMetricType {
             return false
         }
     }
+
+    /// Разрешённые единицы измерения для конкретной метрики
+    var allowedUnits: [UnitType] {
+        switch self {
+        case .reps:
+            return [.repetition]
+        case .weight:
+            return [.kilogram, .pound]
+        case .time:
+            return [.second, .minute]
+        case .distance:
+            return [.meter, .kilometer]
+        case .calories:
+            return [.calorie]
+        case .custom:
+            return UnitType.allCases
+        }
+    }
+
+    /// Приоритет для сортировки метрик
+    var sortOrder: Int {
+        switch self {
+        case .reps: return 0
+        case .weight: return 1
+        case .time: return 2
+        case .distance: return 3
+        case .calories: return 4
+        case .custom: return 5
+        }
+    }
 }

--- a/FitLink/UIAtoms/MetricBadge.swift
+++ b/FitLink/UIAtoms/MetricBadge.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct MetricBadge: View {
+    let metric: ExerciseMetric
+
+    var body: some View {
+        HStack(spacing: 4) {
+            if let icon = metric.iconName {
+                Image(systemName: icon)
+            }
+            Text(metric.displayName)
+        }
+        .font(Theme.font.caption)
+        .padding(.horizontal, Theme.spacing.small)
+        .padding(.vertical, Theme.spacing.extraSmall)
+        .background(Theme.color.badgeBackground)
+        .foregroundColor(Theme.color.textPrimary)
+        .clipShape(Capsule())
+    }
+}
+
+#if DEBUG
+#Preview {
+    HStack(spacing: 8) {
+        MetricBadge(metric: ExerciseMetric(type: .reps, unit: .repetition, isRequired: true))
+        MetricBadge(metric: ExerciseMetric(type: .weight, unit: .kilogram, isRequired: false))
+    }
+    .padding()
+    .previewLayout(.sizeThatFits)
+}
+#endif

--- a/FitLink/UIAtoms/MetricBadge.swift
+++ b/FitLink/UIAtoms/MetricBadge.swift
@@ -9,7 +9,7 @@ struct MetricBadge: View {
                 Image(systemName: icon)
             }
             Text(metric.displayName)
-        }
+        } //: HStack
         .font(Theme.font.caption)
         .padding(.horizontal, Theme.spacing.small)
         .padding(.vertical, Theme.spacing.extraSmall)
@@ -24,7 +24,7 @@ struct MetricBadge: View {
     HStack(spacing: 8) {
         MetricBadge(metric: ExerciseMetric(type: .reps, unit: .repetition, isRequired: true))
         MetricBadge(metric: ExerciseMetric(type: .weight, unit: .kilogram, isRequired: false))
-    }
+    } //: HStack
     .padding()
     .previewLayout(.sizeThatFits)
 }

--- a/FitLink/UIAtoms/MetricBadge.swift
+++ b/FitLink/UIAtoms/MetricBadge.swift
@@ -9,6 +9,7 @@ struct MetricBadge: View {
                 Image(systemName: icon)
             }
             Text(metric.displayName)
+                .lineLimit(1)
         } //: HStack
         .font(Theme.font.caption)
         .padding(.horizontal, Theme.spacing.small)

--- a/FitLink/UIAtoms/MuscleGroupBadge.swift
+++ b/FitLink/UIAtoms/MuscleGroupBadge.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct MuscleGroupBadge: View {
+    let group: MuscleGroup
+    var isMain: Bool = false
+
+    var body: some View {
+        Text(group.displayName)
+            .font(Theme.font.caption)
+            .padding(.horizontal, Theme.spacing.small)
+            .padding(.vertical, Theme.spacing.extraSmall)
+            .background(isMain ? group.color : group.color.opacity(0.18))
+            .foregroundColor(isMain ? .white : group.color)
+            .clipShape(Capsule())
+    }
+}
+
+#if DEBUG
+#Preview {
+    VStack(spacing: 8) {
+        MuscleGroupBadge(group: .biceps)
+        MuscleGroupBadge(group: .chest, isMain: true)
+    }
+    .padding()
+    .previewLayout(.sizeThatFits)
+}
+#endif

--- a/FitLink/UIAtoms/MuscleGroupBadge.swift
+++ b/FitLink/UIAtoms/MuscleGroupBadge.swift
@@ -20,7 +20,7 @@ struct MuscleGroupBadge: View {
     VStack(spacing: 8) {
         MuscleGroupBadge(group: .biceps)
         MuscleGroupBadge(group: .chest, isMain: true)
-    }
+    } //: VStack
     .padding()
     .previewLayout(.sizeThatFits)
 }

--- a/FitLink/UIAtoms/VariationBadge.swift
+++ b/FitLink/UIAtoms/VariationBadge.swift
@@ -23,9 +23,11 @@ struct VariationBadge: View {
 #if DEBUG
 struct VariationBadge_Previews: PreviewProvider {
     static var previews: some View {
-        VariationBadge(variation: "Классический")
-            .padding()
-            .previewLayout(.sizeThatFits)
+        VStack {
+            VariationBadge(variation: "Классический")
+        } //: VStack
+        .padding()
+        .previewLayout(.sizeThatFits)
     }
 }
 #endif

--- a/FitLink/Views/ExerciseDetail/ExerciseDetailView.swift
+++ b/FitLink/Views/ExerciseDetail/ExerciseDetailView.swift
@@ -20,9 +20,11 @@ struct ExerciseDetailView: View {
                         .padding(.horizontal)
                 }
 
-                mediaView
-                    .frame(maxWidth: .infinity, maxHeight: 220)
-                    .padding(.horizontal)
+                if viewModel.exercise.mediaURL != nil {
+                    mediaView
+                        .frame(maxWidth: .infinity, maxHeight: 220)
+                        .padding(.horizontal)
+                }
 
                 if !viewModel.exercise.variations.isEmpty {
                     Text(NSLocalizedString("ExerciseDetail.Variations", comment: "Variations"))
@@ -41,7 +43,7 @@ struct ExerciseDetailView: View {
                         .font(Theme.font.subheading)
                         .padding(.horizontal)
                     LazyVGrid(columns: [GridItem(.adaptive(minimum: 80))], spacing: Theme.spacing.small) {
-                        ForEach(viewModel.exercise.metrics, id: \.self) { MetricBadge(metric: $0) }
+                        ForEach(viewModel.exercise.metrics.sorted { $0.type.sortOrder < $1.type.sortOrder }, id: \.self) { MetricBadge(metric: $0) }
                     }
                     .padding(.horizontal)
                 }
@@ -51,7 +53,8 @@ struct ExerciseDetailView: View {
                         .font(Theme.font.subheading)
                         .padding(.horizontal)
                     LazyVGrid(columns: [GridItem(.adaptive(minimum: 80))], spacing: Theme.spacing.small) {
-                        ForEach(viewModel.exercise.muscleGroups, id: \.self) { group in
+                        let groups = [viewModel.exercise.mainMuscle] + viewModel.exercise.muscleGroups.filter { $0 != viewModel.exercise.mainMuscle }
+                        ForEach(groups, id: \.self) { group in
                             MuscleGroupBadge(group: group, isMain: group == viewModel.exercise.mainMuscle)
                         }
                     }
@@ -61,7 +64,6 @@ struct ExerciseDetailView: View {
             .padding(.vertical, Theme.spacing.medium)
         } //: ScrollView
         .background(Theme.color.background)
-        .navigationTitle(viewModel.exercise.name)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(NSLocalizedString("ExerciseDetail.Edit", comment: "Edit")) {
@@ -86,11 +88,6 @@ struct ExerciseDetailView: View {
                 }
             }
             .clipShape(RoundedRectangle(cornerRadius: Theme.radius.image))
-        } else {
-            Rectangle()
-                .fill(Theme.color.backgroundSecondary)
-                .overlay(Image(systemName: "photo"))
-                .clipShape(RoundedRectangle(cornerRadius: Theme.radius.image))
         }
     }
 }

--- a/FitLink/Views/ExerciseDetail/ExerciseDetailView.swift
+++ b/FitLink/Views/ExerciseDetail/ExerciseDetailView.swift
@@ -59,7 +59,7 @@ struct ExerciseDetailView: View {
                 }
             } //: VStack
             .padding(.vertical, Theme.spacing.medium)
-        }
+        } //: ScrollView
         .background(Theme.color.background)
         .navigationTitle(viewModel.exercise.name)
         .toolbar {

--- a/FitLink/Views/ExerciseDetail/ExerciseDetailView.swift
+++ b/FitLink/Views/ExerciseDetail/ExerciseDetailView.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+struct ExerciseDetailView: View {
+    @StateObject private var viewModel: ExerciseDetailViewModel
+
+    init(exerciseId: UUID) {
+        _viewModel = StateObject(wrappedValue: ExerciseDetailViewModel(exerciseId: exerciseId, dataStore: .shared))
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Theme.spacing.medium) {
+                Text(viewModel.exercise.name)
+                    .font(Theme.font.titleMedium.bold())
+                    .padding(.horizontal)
+
+                if let desc = viewModel.exercise.description, !desc.isEmpty {
+                    Text(desc)
+                        .font(Theme.font.body)
+                        .padding(.horizontal)
+                }
+
+                mediaView
+                    .frame(maxWidth: .infinity, maxHeight: 220)
+                    .padding(.horizontal)
+
+                if !viewModel.exercise.variations.isEmpty {
+                    Text(NSLocalizedString("ExerciseDetail.Variations", comment: "Variations"))
+                        .font(Theme.font.subheading)
+                        .padding(.horizontal)
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: Theme.spacing.small) {
+                            ForEach(viewModel.exercise.variations, id: \.self) { VariationBadge(variation: $0) }
+                        }
+                        .padding(.horizontal)
+                    }
+                }
+
+                if !viewModel.exercise.metrics.isEmpty {
+                    Text(NSLocalizedString("ExerciseDetail.Metrics", comment: "Metrics"))
+                        .font(Theme.font.subheading)
+                        .padding(.horizontal)
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 80))], spacing: Theme.spacing.small) {
+                        ForEach(viewModel.exercise.metrics, id: \.self) { MetricBadge(metric: $0) }
+                    }
+                    .padding(.horizontal)
+                }
+
+                if !viewModel.exercise.muscleGroups.isEmpty {
+                    Text(NSLocalizedString("ExerciseDetail.MuscleGroups", comment: "Muscles"))
+                        .font(Theme.font.subheading)
+                        .padding(.horizontal)
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 80))], spacing: Theme.spacing.small) {
+                        ForEach(viewModel.exercise.muscleGroups, id: \.self) { group in
+                            MuscleGroupBadge(group: group, isMain: group == viewModel.exercise.mainMuscle)
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+            } //: VStack
+            .padding(.vertical, Theme.spacing.medium)
+        }
+        .background(Theme.color.background)
+        .navigationTitle(viewModel.exercise.name)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(NSLocalizedString("ExerciseDetail.Edit", comment: "Edit")) {
+                    viewModel.editTapped()
+                }
+            }
+        }
+        .sheet(isPresented: $viewModel.showEdit) {
+            ExerciseEditView(exercise: viewModel.exercise)
+        }
+    }
+
+    @ViewBuilder
+    private var mediaView: some View {
+        if let url = viewModel.exercise.mediaURL {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().scaledToFill().clipped()
+                default:
+                    Rectangle().fill(Theme.color.backgroundSecondary)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: Theme.radius.image))
+        } else {
+            Rectangle()
+                .fill(Theme.color.backgroundSecondary)
+                .overlay(Image(systemName: "photo"))
+                .clipShape(RoundedRectangle(cornerRadius: Theme.radius.image))
+        }
+    }
+}
+
+#Preview {
+    ExerciseDetailView(exerciseId: exercisesCatalog.first!.id)
+}
+

--- a/FitLink/Views/ExerciseDetail/ExerciseDetailViewModel.swift
+++ b/FitLink/Views/ExerciseDetail/ExerciseDetailViewModel.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Combine
+
+@MainActor
+final class ExerciseDetailViewModel: ObservableObject {
+    @Published var exercise: Exercise
+    @Published var showEdit: Bool = false
+
+    private let dataStore: AppDataStore
+    private let exerciseId: UUID
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(exerciseId: UUID, dataStore: AppDataStore) {
+        self.exerciseId = exerciseId
+        self.dataStore = dataStore
+        self.exercise = dataStore.exercises.first { $0.id == exerciseId }!
+
+        dataStore.$exercises
+            .compactMap { $0.first(where: { $0.id == exerciseId }) }
+            .assign(to: &$exercise)
+    }
+
+    func editTapped() {
+        showEdit = true
+    }
+}
+

--- a/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
+++ b/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
@@ -64,20 +64,20 @@ struct ExerciseEditView: View {
 
                 Section(header: Text(NSLocalizedString("ExerciseEdit.Metrics", comment: ""))) {
                     ForEach(viewModel.metrics.indices, id: \.self) { index in
-                        let $metric = $viewModel.metrics[index]
+                        let metricBinding = $viewModel.metrics[index]
                         VStack(alignment: .leading) {
-                            Picker(NSLocalizedString("ExerciseEdit.MetricType", comment: ""), selection: $metric.type) {
+                            Picker(NSLocalizedString("ExerciseEdit.MetricType", comment: ""), selection: metricBinding.type) {
                                 ForEach(ExerciseMetricType.allCases, id: \.self) { type in
                                     Text(type.displayName).tag(type)
                                 }
                             }
-                            Picker(NSLocalizedString("ExerciseEdit.Unit", comment: ""), selection: $metric.unit) {
+                            Picker(NSLocalizedString("ExerciseEdit.Unit", comment: ""), selection: metricBinding.unit) {
                                 Text("-").tag(UnitType?.none)
                                 ForEach(UnitType.allCases, id: \.self) { unit in
                                     Text(unit.displayName).tag(Optional(unit))
                                 }
                             }
-                            Toggle(NSLocalizedString("ExerciseEdit.Required", comment: ""), isOn: $metric.isRequired)
+                            Toggle(NSLocalizedString("ExerciseEdit.Required", comment: ""), isOn: metricBinding.isRequired)
                         }
                     }
                     .onDelete(perform: viewModel.removeMetric)
@@ -85,7 +85,7 @@ struct ExerciseEditView: View {
                         viewModel.addMetric()
                     }
                 }
-            }
+            } //: List
             .listStyle(.insetGrouped)
             .navigationTitle(viewModel.isNew ? NSLocalizedString("ExerciseEdit.NewTitle", comment: "") : NSLocalizedString("ExerciseEdit.EditTitle", comment: ""))
             .toolbar {
@@ -100,7 +100,7 @@ struct ExerciseEditView: View {
                     .disabled(!viewModel.canSave)
                 }
             }
-        }
+        } //: NavigationStack
     }
 }
 

--- a/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
+++ b/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
@@ -63,7 +63,8 @@ struct ExerciseEditView: View {
                 }
 
                 Section(header: Text(NSLocalizedString("ExerciseEdit.Metrics", comment: ""))) {
-                    ForEach($viewModel.metrics) { $metric in
+                    ForEach(viewModel.metrics.indices, id: \.self) { index in
+                        let $metric = $viewModel.metrics[index]
                         VStack(alignment: .leading) {
                             Picker(NSLocalizedString("ExerciseEdit.MetricType", comment: ""), selection: $metric.type) {
                                 ForEach(ExerciseMetricType.allCases, id: \.self) { type in

--- a/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
+++ b/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
@@ -66,16 +66,33 @@ struct ExerciseEditView: View {
                     ForEach(viewModel.metrics.indices, id: \.self) { index in
                         let metricBinding = $viewModel.metrics[index]
                         VStack(alignment: .leading) {
-                            Picker(NSLocalizedString("ExerciseEdit.MetricType", comment: ""), selection: metricBinding.type) {
+                            Picker(NSLocalizedString("ExerciseEdit.MetricType", comment: ""), selection: Binding(
+                                get: { metricBinding.wrappedValue.type },
+                                set: { newType in
+                                    metricBinding.wrappedValue.type = newType
+                                    if !newType.allowedUnits.contains(metricBinding.wrappedValue.unit ?? .repetition) {
+                                        metricBinding.wrappedValue.unit = newType.allowedUnits.first
+                                    }
+                                }
+                            )) {
                                 ForEach(ExerciseMetricType.allCases, id: \.self) { type in
                                     Text(type.displayName).tag(type)
                                 }
                             }
-                            Picker(NSLocalizedString("ExerciseEdit.Unit", comment: ""), selection: metricBinding.unit) {
-                                Text("-").tag(UnitType?.none)
-                                ForEach(UnitType.allCases, id: \.self) { unit in
-                                    Text(unit.displayName).tag(Optional(unit))
+                            if metricBinding.wrappedValue.type != .reps {
+                                Picker(NSLocalizedString("ExerciseEdit.Unit", comment: ""), selection: Binding(
+                                    get: { metricBinding.wrappedValue.unit },
+                                    set: { metricBinding.wrappedValue.unit = $0 }
+                                )) {
+                                    Text("-").tag(UnitType?.none)
+                                    ForEach(metricBinding.wrappedValue.type.allowedUnits, id: \.self) { unit in
+                                        Text(unit.displayName).tag(Optional(unit))
+                                    }
                                 }
+                            } else {
+                                Text(UnitType.repetition.displayName)
+                                    .font(Theme.font.caption)
+                                    .foregroundColor(Theme.color.textSecondary)
                             }
                             Toggle(NSLocalizedString("ExerciseEdit.Required", comment: ""), isOn: metricBinding.isRequired)
                         }

--- a/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
+++ b/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+struct ExerciseEditView: View {
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var viewModel: ExerciseEditViewModel
+
+    init(exercise: Exercise? = nil) {
+        _viewModel = StateObject(wrappedValue: ExerciseEditViewModel(exercise: exercise, dataStore: .shared))
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section(header: Text(NSLocalizedString("ExerciseEdit.Name", comment: ""))) {
+                    TextField("", text: $viewModel.name)
+                }
+
+                Section(header: Text(NSLocalizedString("ExerciseEdit.Description", comment: ""))) {
+                    TextEditor(text: $viewModel.description)
+                        .frame(minHeight: 100)
+                }
+
+                Section(header: Text(NSLocalizedString("ExerciseEdit.Media", comment: ""))) {
+                    Button(NSLocalizedString("ExerciseEdit.MediaPlaceholder", comment: "")) {
+                        // TODO: Implement media picker
+                    }
+                }
+
+                Section(header: Text(NSLocalizedString("ExerciseEdit.Variations", comment: ""))) {
+                    ForEach(viewModel.variations, id: \.self) { variation in
+                        Text(variation)
+                    }
+                    .onDelete(perform: viewModel.removeVariation)
+
+                    HStack {
+                        TextField(NSLocalizedString("ExerciseEdit.VariationPlaceholder", comment: ""), text: $viewModel.newVariation)
+                        Button(action: viewModel.addVariation) {
+                            Image(systemName: "plus.circle.fill")
+                        }
+                    }
+                }
+
+                Section(header: Text(NSLocalizedString("ExerciseEdit.MuscleGroups", comment: ""))) {
+                    ForEach(MuscleGroup.allStandardCases, id: \.self) { group in
+                        HStack {
+                            Text(group.displayName)
+                            Spacer()
+                            if viewModel.selectedGroups.contains(group) {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                        .contentShape(Rectangle())
+                        .onTapGesture { viewModel.toggleGroup(group) }
+                    }
+                }
+
+                Section(header: Text(NSLocalizedString("ExerciseEdit.MainMuscle", comment: ""))) {
+                    Picker("", selection: Binding(get: { viewModel.mainGroup ?? viewModel.selectedGroups.first }, set: { viewModel.mainGroup = $0 })) {
+                        ForEach(Array(viewModel.selectedGroups), id: \.self) { group in
+                            Text(group.displayName).tag(Optional(group))
+                        }
+                    }
+                }
+
+                Section(header: Text(NSLocalizedString("ExerciseEdit.Metrics", comment: ""))) {
+                    ForEach($viewModel.metrics) { $metric in
+                        VStack(alignment: .leading) {
+                            Picker(NSLocalizedString("ExerciseEdit.MetricType", comment: ""), selection: $metric.type) {
+                                ForEach(ExerciseMetricType.allCases, id: \.self) { type in
+                                    Text(type.displayName).tag(type)
+                                }
+                            }
+                            Picker(NSLocalizedString("ExerciseEdit.Unit", comment: ""), selection: $metric.unit) {
+                                Text("-").tag(UnitType?.none)
+                                ForEach(UnitType.allCases, id: \.self) { unit in
+                                    Text(unit.displayName).tag(Optional(unit))
+                                }
+                            }
+                            Toggle(NSLocalizedString("ExerciseEdit.Required", comment: ""), isOn: $metric.isRequired)
+                        }
+                    }
+                    .onDelete(perform: viewModel.removeMetric)
+                    Button(NSLocalizedString("ExerciseEdit.AddMetric", comment: "")) {
+                        viewModel.addMetric()
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle(viewModel.isNew ? NSLocalizedString("ExerciseEdit.NewTitle", comment: "") : NSLocalizedString("ExerciseEdit.EditTitle", comment: ""))
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(NSLocalizedString("Common.Cancel", comment: "")) { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(NSLocalizedString("Common.Save", comment: "")) {
+                        viewModel.save()
+                        dismiss()
+                    }
+                    .disabled(!viewModel.canSave)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    ExerciseEditView(exercise: exercisesCatalog.first!)
+}
+

--- a/FitLink/Views/ExerciseEdit/ExerciseEditViewModel.swift
+++ b/FitLink/Views/ExerciseEdit/ExerciseEditViewModel.swift
@@ -67,7 +67,7 @@ final class ExerciseEditViewModel: ObservableObject {
     }
 
     func addMetric() {
-        metrics.append(ExerciseMetric(type: .reps, unit: nil, isRequired: false))
+        metrics.append(ExerciseMetric(type: .reps, unit: .repetition, isRequired: false))
     }
 
     func removeMetric(at offsets: IndexSet) {
@@ -76,14 +76,18 @@ final class ExerciseEditViewModel: ObservableObject {
 
     func save() {
         guard canSave else { return }
+        var groups: [MuscleGroup] = []
+        if let mainGroup { groups.append(mainGroup) }
+        groups.append(contentsOf: selectedGroups.filter { $0 != mainGroup })
+        let sortedMetrics = metrics.sorted { $0.type.sortOrder < $1.type.sortOrder }
         let exercise = Exercise(
             id: exerciseId,
             name: name,
             description: description.isEmpty ? nil : description,
             mediaURL: mediaURL,
             variations: variations,
-            muscleGroups: Array(selectedGroups),
-            metrics: metrics
+            muscleGroups: groups,
+            metrics: sortedMetrics
         )
         dataStore.saveExercise(exercise)
     }

--- a/FitLink/Views/ExerciseEdit/ExerciseEditViewModel.swift
+++ b/FitLink/Views/ExerciseEdit/ExerciseEditViewModel.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Combine
+
+@MainActor
+final class ExerciseEditViewModel: ObservableObject {
+    @Published var name: String
+    @Published var description: String
+    @Published var mediaURL: URL?
+    @Published var variations: [String]
+    @Published var newVariation: String = ""
+    @Published var selectedGroups: Set<MuscleGroup>
+    @Published var mainGroup: MuscleGroup?
+    @Published var metrics: [ExerciseMetric]
+
+    private let dataStore: AppDataStore
+    private let exerciseId: UUID
+    let isNew: Bool
+
+    init(exercise: Exercise? = nil, dataStore: AppDataStore) {
+        self.dataStore = dataStore
+        if let exercise {
+            self.isNew = false
+            self.exerciseId = exercise.id
+            self.name = exercise.name
+            self.description = exercise.description ?? ""
+            self.mediaURL = exercise.mediaURL
+            self.variations = exercise.variations
+            self.selectedGroups = Set(exercise.muscleGroups)
+            self.mainGroup = exercise.mainMuscle
+            self.metrics = exercise.metrics
+        } else {
+            self.isNew = true
+            self.exerciseId = UUID()
+            self.name = ""
+            self.description = ""
+            self.mediaURL = nil
+            self.variations = []
+            self.selectedGroups = []
+            self.mainGroup = nil
+            self.metrics = []
+        }
+    }
+
+    var canSave: Bool {
+        !name.trimmingCharacters(in: .whitespaces).isEmpty && !selectedGroups.isEmpty
+    }
+
+    func addVariation() {
+        let value = newVariation.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return }
+        variations.append(value)
+        newVariation = ""
+    }
+
+    func removeVariation(at offsets: IndexSet) {
+        variations.remove(atOffsets: offsets)
+    }
+
+    func toggleGroup(_ group: MuscleGroup) {
+        if selectedGroups.contains(group) {
+            selectedGroups.remove(group)
+            if mainGroup == group { mainGroup = selectedGroups.first }
+        } else {
+            selectedGroups.insert(group)
+            if mainGroup == nil { mainGroup = group }
+        }
+    }
+
+    func addMetric() {
+        metrics.append(ExerciseMetric(type: .reps, unit: nil, isRequired: false))
+    }
+
+    func removeMetric(at offsets: IndexSet) {
+        metrics.remove(atOffsets: offsets)
+    }
+
+    func save() {
+        guard canSave else { return }
+        let exercise = Exercise(
+            id: exerciseId,
+            name: name,
+            description: description.isEmpty ? nil : description,
+            mediaURL: mediaURL,
+            variations: variations,
+            muscleGroups: Array(selectedGroups),
+            metrics: metrics
+        )
+        dataStore.saveExercise(exercise)
+    }
+}
+

--- a/FitLink/Views/ExerciseLibrary/ExerciseLibraryView.swift
+++ b/FitLink/Views/ExerciseLibrary/ExerciseLibraryView.swift
@@ -13,6 +13,7 @@ struct ExerciseLibraryView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel = ExerciseLibraryViewModel(dataStore: .shared)
     @State private var showFilterDialog = false
+    @State private var showCreate = false
 
     var body: some View {
         NavigationStack {
@@ -21,9 +22,7 @@ struct ExerciseLibraryView: View {
                     Text(NSLocalizedString("ExerciseLibrary.Header", comment: "Упражнения"))
                         .font(.title2.bold())
                     Spacer()
-                    Button(action: {
-                        // Экран добавления упражнения
-                    }) {
+                    Button(action: { showCreate = true }) {
                         Image(systemName: "plus")
                             .font(.title2)
                     }
@@ -49,11 +48,18 @@ struct ExerciseLibraryView: View {
                 ScrollView {
                     LazyVStack(spacing: 12) {
                         ForEach(viewModel.filteredExercises) { exercise in
-                            ExerciseRow(exercise: exercise)
-                                .onTapGesture {
-                                    onSelect?(exercise)
-                                    if onSelect != nil { dismiss() }
+                            if onSelect == nil {
+                                NavigationLink(value: exercise.id) {
+                                    ExerciseRow(exercise: exercise)
                                 }
+                                .buttonStyle(.plain)
+                            } else {
+                                ExerciseRow(exercise: exercise)
+                                    .onTapGesture {
+                                        onSelect?(exercise)
+                                        dismiss()
+                                    }
+                            }
                         }
                     }
                     .padding()
@@ -64,6 +70,12 @@ struct ExerciseLibraryView: View {
             )
             .background(Theme.color.background)
             .navigationBarHidden(true)
+            .sheet(isPresented: $showCreate) {
+                ExerciseEditView()
+            }
+            .navigationDestination(for: UUID.self) { id in
+                ExerciseDetailView(exerciseId: id)
+            }
         }
     }
 }

--- a/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionView.swift
@@ -78,8 +78,7 @@ struct WorkoutSessionView: View {
                 .padding()
         }
         .sheet(item: $viewModel.detailExercise) { exercise in
-            Text("Details for \(exercise.exercise.name)")
-                .padding()
+            ExerciseDetailView(exerciseId: exercise.exercise.id)
         }
     }
 

--- a/FitLink/Views/WorkoutSession/WorkoutSessionViewModel.swift
+++ b/FitLink/Views/WorkoutSession/WorkoutSessionViewModel.swift
@@ -177,7 +177,7 @@ final class WorkoutSessionViewModel: ObservableObject {
     func editSet(withID setId: UUID, ofExercise exerciseId: UUID) {
         guard let exerciseIndex = exercises.firstIndex(where: { $0.id == exerciseId }) else { return }
         let exercise = exercises[exerciseIndex]
-        let metrics = exercise.exercise.metrics.sorted { metricOrder($0.type) < metricOrder($1.type) }
+        let metrics = exercise.exercise.metrics.sorted { $0.type.sortOrder < $1.type.sortOrder }
         for approach in exercise.approaches {
             if let set = approach.sets.first(where: { $0.id == setId }) {
                 var values: [ExerciseMetric.ID: ExerciseMetricValue] = [:]
@@ -192,7 +192,7 @@ final class WorkoutSessionViewModel: ObservableObject {
 
     func addSet(toExercise exerciseId: UUID) {
         guard let exercise = exercises.first(where: { $0.id == exerciseId }) else { return }
-        let metrics = exercise.exercise.metrics.sorted { metricOrder($0.type) < metricOrder($1.type) }
+        let metrics = exercise.exercise.metrics.sorted { $0.type.sortOrder < $1.type.sortOrder }
         var values: [ExerciseMetric.ID: ExerciseMetricValue] = [:]
         for metric in metrics {
             values[metric.id] = metric.type.requiresInteger ? .int(0) : .double(0)
@@ -593,11 +593,4 @@ final class WorkoutSessionViewModel: ObservableObject {
         return ExerciseInstance(id: UUID(), exercise: instance.exercise, approaches: approaches, groupId: newGroupId, notes: instance.notes, section: instance.section)
     }
 
-    private func metricOrder(_ type: ExerciseMetricType) -> Int {
-        switch type {
-        case .reps: return 0
-        case .weight: return 1
-        default: return 2
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- add reusable `MuscleGroupBadge` and `MetricBadge` UIAtoms
- allow adding/updating exercises via `saveExercise` in `AppDataStore`
- implement `ExerciseDetailView` with editing option
- implement `ExerciseEditView` for create/edit flows
- integrate detail navigation in `ExerciseLibraryView` and workout session
- provide localization for new screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fce3829a483308e075a9dc816e889