### PR TITLE
Implement simple markdown renderer for Exercise Detail

### DIFF
--- a/FitLink/UIAtoms/MarkdownTextView.swift
+++ b/FitLink/UIAtoms/MarkdownTextView.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+/// Simple view that renders a small subset of Markdown (bold and italics)
+/// while ignoring unsupported elements. Emojis are rendered as part of the text.
+struct MarkdownTextView: View {
+    /// Raw markdown text to display
+    let text: String
+
+    var body: some View {
+        parsedText(from: text)
+            .multilineTextAlignment(.leading)
+    }
+
+    /// Parses the input markdown and returns a concatenated `Text` view.
+    private func parsedText(from string: String) -> Text {
+        let tokens = MarkdownParser.parse(string)
+        // Build the Text by concatenating styled segments
+        return tokens.reduce(Text("")) { partial, token in
+            partial + token.asText()
+        }
+    }
+}
+
+/// Token representing a piece of markdown text with a specific style.
+private struct MarkdownToken {
+    enum Style {
+        case normal, bold, italic, boldItalic
+    }
+
+    var text: String
+    var style: Style
+
+    /// Converts the token to a SwiftUI `Text` with the correct formatting.
+    func asText() -> Text {
+        var result = Text(text)
+            .font(Theme.font.body)
+        switch style {
+        case .bold:
+            result = result.bold()
+        case .italic:
+            result = result.italic()
+        case .boldItalic:
+            result = result.bold().italic()
+        case .normal:
+            break
+        }
+        return result
+    }
+}
+
+/// Basic Markdown parser supporting bold (**text**) and italics (*text*).
+/// Unsupported syntax is rendered as plain text.
+private enum MarkdownParser {
+    static func parse(_ text: String) -> [MarkdownToken] {
+        var tokens: [MarkdownToken] = []
+        var index = text.startIndex
+        var buffer = ""
+        var isBold = false
+        var isItalic = false
+
+        func flush() {
+            guard !buffer.isEmpty else { return }
+            let style: MarkdownToken.Style
+            switch (isBold, isItalic) {
+            case (true, true): style = .boldItalic
+            case (true, false): style = .bold
+            case (false, true): style = .italic
+            default: style = .normal
+            }
+            tokens.append(MarkdownToken(text: buffer, style: style))
+            buffer.removeAll()
+        }
+
+        while index < text.endIndex {
+            if text[index...].hasPrefix("**") {
+                // Look ahead for a closing '**'
+                let searchStart = text.index(index, offsetBy: 2)
+                if let _ = text.range(of: "**", range: searchStart..<text.endIndex) {
+                    flush()
+                    isBold.toggle()
+                    index = text.index(index, offsetBy: 2)
+                    continue
+                } else {
+                    buffer.append("**")
+                    index = text.index(index, offsetBy: 2)
+                    continue
+                }
+            } else if text[index] == "*" {
+                // Look ahead for a closing '*'
+                let searchStart = text.index(after: index)
+                if let _ = text.range(of: "*", range: searchStart..<text.endIndex) {
+                    flush()
+                    isItalic.toggle()
+                    index = text.index(after: index)
+                    continue
+                } else {
+                    buffer.append("*")
+                    index = text.index(after: index)
+                    continue
+                }
+            }
+
+            buffer.append(text[index])
+            index = text.index(after: index)
+        }
+        flush()
+        return tokens
+    }
+}
+
+#if DEBUG
+#Preview {
+    VStack(alignment: .leading, spacing: Theme.spacing.small) {
+        MarkdownTextView(text: "This is **bold** text, this is *italic*, and here is a smiley 😄.")
+        MarkdownTextView(text: "Nested **bold and *italic* together** works as well.")
+        MarkdownTextView(text: "Unmatched asterisks *are rendered** literally.")
+    } //: VStack
+    .padding()
+}
+#endif

--- a/FitLink/UIAtoms/MarkdownTextView.swift
+++ b/FitLink/UIAtoms/MarkdownTextView.swift
@@ -1,110 +1,30 @@
 import SwiftUI
 
-/// Simple view that renders a small subset of Markdown (bold and italics)
-/// while ignoring unsupported elements. Emojis are rendered as part of the text.
+/// View that renders a subset of Markdown (bold and italics) while keeping
+/// emojis inline. Unsupported elements are shown as plain text.
 struct MarkdownTextView: View {
     /// Raw markdown text to display
     let text: String
 
     var body: some View {
-        parsedText(from: text)
+        Text(MarkdownRenderer.attributedString(from: text))
+            .font(Theme.font.body)
             .multilineTextAlignment(.leading)
     }
-
-    /// Parses the input markdown and returns a concatenated `Text` view.
-    private func parsedText(from string: String) -> Text {
-        let tokens = MarkdownParser.parse(string)
-        // Build the Text by concatenating styled segments
-        return tokens.reduce(Text("")) { partial, token in
-            partial + token.asText()
-        }
-    }
 }
 
-/// Token representing a piece of markdown text with a specific style.
-private struct MarkdownToken {
-    enum Style {
-        case normal, bold, italic, boldItalic
-    }
-
-    var text: String
-    var style: Style
-
-    /// Converts the token to a SwiftUI `Text` with the correct formatting.
-    func asText() -> Text {
-        var result = Text(text)
-            .font(Theme.font.body)
-        switch style {
-        case .bold:
-            result = result.bold()
-        case .italic:
-            result = result.italic()
-        case .boldItalic:
-            result = result.bold().italic()
-        case .normal:
-            break
+/// Helper responsible for converting markdown strings into `AttributedString`
+/// instances using the Foundation parser available on iOS 15+.
+enum MarkdownRenderer {
+    static func attributedString(from string: String) -> AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        if let parsed = try? AttributedString(markdown: string, options: options) {
+            return parsed
+        } else {
+            return AttributedString(string)
         }
-        return result
-    }
-}
-
-/// Basic Markdown parser supporting bold (**text**) and italics (*text*).
-/// Unsupported syntax is rendered as plain text.
-private enum MarkdownParser {
-    static func parse(_ text: String) -> [MarkdownToken] {
-        var tokens: [MarkdownToken] = []
-        var index = text.startIndex
-        var buffer = ""
-        var isBold = false
-        var isItalic = false
-
-        func flush() {
-            guard !buffer.isEmpty else { return }
-            let style: MarkdownToken.Style
-            switch (isBold, isItalic) {
-            case (true, true): style = .boldItalic
-            case (true, false): style = .bold
-            case (false, true): style = .italic
-            default: style = .normal
-            }
-            tokens.append(MarkdownToken(text: buffer, style: style))
-            buffer.removeAll()
-        }
-
-        while index < text.endIndex {
-            if text[index...].hasPrefix("**") {
-                // Look ahead for a closing '**'
-                let searchStart = text.index(index, offsetBy: 2)
-                if let _ = text.range(of: "**", range: searchStart..<text.endIndex) {
-                    flush()
-                    isBold.toggle()
-                    index = text.index(index, offsetBy: 2)
-                    continue
-                } else {
-                    buffer.append("**")
-                    index = text.index(index, offsetBy: 2)
-                    continue
-                }
-            } else if text[index] == "*" {
-                // Look ahead for a closing '*'
-                let searchStart = text.index(after: index)
-                if let _ = text.range(of: "*", range: searchStart..<text.endIndex) {
-                    flush()
-                    isItalic.toggle()
-                    index = text.index(after: index)
-                    continue
-                } else {
-                    buffer.append("*")
-                    index = text.index(after: index)
-                    continue
-                }
-            }
-
-            buffer.append(text[index])
-            index = text.index(after: index)
-        }
-        flush()
-        return tokens
     }
 }
 

--- a/FitLink/Views/ExerciseDetail/ExerciseDetailView.swift
+++ b/FitLink/Views/ExerciseDetail/ExerciseDetailView.swift
@@ -15,8 +15,7 @@ struct ExerciseDetailView: View {
                     .padding(.horizontal)
 
                 if let desc = viewModel.exercise.description, !desc.isEmpty {
-                    Text(desc)
-                        .font(Theme.font.body)
+                    MarkdownTextView(text: desc)
                         .padding(.horizontal)
                 }
 


### PR DESCRIPTION
## Summary
- create `MarkdownTextView` atom to render bold and italic markdown
- update exercise detail screen to use the markdown renderer for descriptions

## Testing
- `swiftc FitLink/UIAtoms/MarkdownTextView.swift -o /tmp/out` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685fdc1a10848330ba19db464bd43918