### PR TITLE
Implement asynchronous media storage

### DIFF
--- a/FitLink/CommonServices/AppDataStore.swift
+++ b/FitLink/CommonServices/AppDataStore.swift
@@ -9,6 +9,8 @@ class AppDataStore: ObservableObject {
     @Published var sessions: [WorkoutSession]
     @Published var exercises: [Exercise]
 
+    private let mediaManager = ExerciseMediaManager.shared
+
     var clientsById: [UUID: Client] {
         Dictionary(uniqueKeysWithValues: clients.map { ($0.id, $0) })
     }
@@ -48,4 +50,46 @@ class AppDataStore: ObservableObject {
             exercises.append(exercise)
         }
     }
+
+    // MARK: - Media management
+
+    /// Saves a media file for the given exercise from a temporary location.
+    /// The resulting URL is stored on the exercise and returned.
+    func saveMedia(for exercise: Exercise, from tempURL: URL) async throws -> URL {
+        let url = try await mediaManager.saveMedia(for: exercise.id, from: tempURL)
+        var updated = exercise
+        updated.mediaURL = url
+        saveExercise(updated)
+        return url
+    }
+
+    /// Removes the media file associated with the exercise and clears its `mediaURL`.
+    func removeMedia(for exercise: Exercise) async throws {
+        try await mediaManager.removeMedia(for: exercise.id)
+        var updated = exercise
+        updated.mediaURL = nil
+        saveExercise(updated)
+    }
+
+    /// Replaces an existing media file with a new one.
+    func updateMedia(for exercise: Exercise, with tempURL: URL) async throws -> URL {
+        let url = try await mediaManager.updateMedia(for: exercise.id, with: tempURL)
+        var updated = exercise
+        updated.mediaURL = url
+        saveExercise(updated)
+        return url
+    }
+
+    /// Deletes an exercise and its associated media file.
+    func deleteExercise(_ exercise: Exercise) async throws {
+        try await mediaManager.removeMedia(for: exercise.id)
+        exercises.removeAll { $0.id == exercise.id }
+    }
+
+    /// Removes media files that no longer have a corresponding exercise entry.
+    func cleanupOrphanedMedia() async throws {
+        let ids = Set(exercises.map { $0.id })
+        try await mediaManager.cleanup(orphanedAgainst: ids)
+    }
+
 }

--- a/FitLink/CommonServices/AppDataStore.swift
+++ b/FitLink/CommonServices/AppDataStore.swift
@@ -46,6 +46,7 @@ class AppDataStore: ObservableObject {
     func saveExercise(_ exercise: Exercise) {
         if let index = exercises.firstIndex(where: { $0.id == exercise.id }) {
             exercises[index] = exercise
+            exercises = Array(exercises)
         } else {
             exercises.append(exercise)
         }
@@ -84,6 +85,7 @@ class AppDataStore: ObservableObject {
     func deleteExercise(_ exercise: Exercise) async throws {
         try await mediaManager.removeMedia(for: exercise.id)
         exercises.removeAll { $0.id == exercise.id }
+        exercises = Array(exercises)
     }
 
     /// Removes media files that no longer have a corresponding exercise entry.

--- a/FitLink/CommonServices/ExerciseMediaManager.swift
+++ b/FitLink/CommonServices/ExerciseMediaManager.swift
@@ -1,0 +1,92 @@
+import Foundation
+import UniformTypeIdentifiers
+
+/// Handles saving and removing exercise media files inside the app's document directory.
+/// All file operations are asynchronous and errors are propagated for the caller to handle.
+actor ExerciseMediaManager {
+    static let shared = ExerciseMediaManager()
+
+    private let fileManager = FileManager.default
+    private let directory: URL
+    private let maxFileSize: Int = 15 * 1024 * 1024 // 15 MB
+
+    enum MediaError: LocalizedError {
+        case fileTooLarge
+        case unsupportedFormat
+
+        var errorDescription: String? {
+            switch self {
+            case .fileTooLarge:
+                return NSLocalizedString("Media.Error.TooLarge", comment: "")
+            case .unsupportedFormat:
+                return NSLocalizedString("Media.Error.Unsupported", comment: "")
+            }
+        }
+    }
+
+    private init() {
+        let docs = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        self.directory = docs.appendingPathComponent("exerciseMedia", isDirectory: true)
+    }
+
+    /// Stores media for an exercise from a temporary URL. Returns the final file location.
+    func saveMedia(for exerciseId: UUID, from tempURL: URL) async throws -> URL {
+        try await ensureDirectory()
+        try validateFile(tempURL)
+        let targetURL = directory.appendingPathComponent("\(exerciseId).\(tempURL.pathExtension)")
+        if fileManager.fileExists(atPath: targetURL.path) {
+            try fileManager.removeItem(at: targetURL)
+        }
+        try fileManager.copyItem(at: tempURL, to: targetURL)
+        return targetURL
+    }
+
+    /// Removes media for the provided exercise id if it exists.
+    func removeMedia(for exerciseId: UUID) async throws {
+        guard let existing = try currentMediaURL(for: exerciseId) else { return }
+        try fileManager.removeItem(at: existing)
+    }
+
+    /// Replaces existing media with a new file.
+    func updateMedia(for exerciseId: UUID, with tempURL: URL) async throws -> URL {
+        try await removeMedia(for: exerciseId)
+        return try await saveMedia(for: exerciseId, from: tempURL)
+    }
+
+    /// Cleans up orphaned files that don't correspond to any provided exercise ids.
+    func cleanup(orphanedAgainst exerciseIds: Set<UUID>) async throws {
+        try await ensureDirectory()
+        let contents = try fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+        for url in contents {
+            let idString = url.deletingPathExtension().lastPathComponent
+            if let uuid = UUID(uuidString: idString), !exerciseIds.contains(uuid) {
+                try? fileManager.removeItem(at: url)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+    private func ensureDirectory() async throws {
+        if !fileManager.fileExists(atPath: directory.path) {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+    }
+
+    private func validateFile(_ url: URL) throws {
+        let attrs = try fileManager.attributesOfItem(atPath: url.path)
+        if let size = attrs[.size] as? NSNumber, size.intValue > maxFileSize {
+            throw MediaError.fileTooLarge
+        }
+        guard
+            let type = UTType(filenameExtension: url.pathExtension),
+            type.conforms(to: .image) || type.conforms(to: .movie) || type == .gif
+        else {
+            throw MediaError.unsupportedFormat
+        }
+    }
+
+    private func currentMediaURL(for exerciseId: UUID) throws -> URL? {
+        let contents = try? fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+        return contents?.first { $0.deletingPathExtension().lastPathComponent == exerciseId.uuidString }
+    }
+}

--- a/FitLink/Localization/en.lproj/Localizable.strings
+++ b/FitLink/Localization/en.lproj/Localizable.strings
@@ -207,6 +207,10 @@
 "ExerciseEdit.Unit" = "Unit";
 "ExerciseEdit.Required" = "Required";
 "ExerciseEdit.AddMetric" = "Add Metric";
+"ExerciseEdit.ReplaceMedia" = "Replace Media";
+"ExerciseEdit.RemoveMedia" = "Remove Media";
+"Media.Error.TooLarge" = "File is too large";
+"Media.Error.Unsupported" = "Unsupported format";
 
 /* Common additional */
 "Common.Save" = "Save";

--- a/FitLink/Localization/en.lproj/Localizable.strings
+++ b/FitLink/Localization/en.lproj/Localizable.strings
@@ -211,6 +211,7 @@
 "ExerciseEdit.RemoveMedia" = "Remove Media";
 "Media.Error.TooLarge" = "File is too large";
 "Media.Error.Unsupported" = "Unsupported format";
+"ExerciseEdit.MediaLoadError" = "Could not load selected media";
 
 /* Common additional */
 "Common.Save" = "Save";

--- a/FitLink/Localization/ru.lproj/Localizable.strings
+++ b/FitLink/Localization/ru.lproj/Localizable.strings
@@ -207,6 +207,10 @@
 "ExerciseEdit.Unit" = "Ед.";
 "ExerciseEdit.Required" = "Обязательная";
 "ExerciseEdit.AddMetric" = "Добавить метрику";
+"ExerciseEdit.ReplaceMedia" = "Заменить медиа";
+"ExerciseEdit.RemoveMedia" = "Удалить медиа";
+"Media.Error.TooLarge" = "Файл слишком большой";
+"Media.Error.Unsupported" = "Неподдерживаемый формат";
 
 /* Common additional */
 "Common.Save" = "Сохранить";

--- a/FitLink/Localization/ru.lproj/Localizable.strings
+++ b/FitLink/Localization/ru.lproj/Localizable.strings
@@ -211,6 +211,7 @@
 "ExerciseEdit.RemoveMedia" = "Удалить медиа";
 "Media.Error.TooLarge" = "Файл слишком большой";
 "Media.Error.Unsupported" = "Неподдерживаемый формат";
+"ExerciseEdit.MediaLoadError" = "Не удалось загрузить медиа";
 
 /* Common additional */
 "Common.Save" = "Сохранить";

--- a/FitLink/Views/ExerciseDetail/ExerciseDetailView.swift
+++ b/FitLink/Views/ExerciseDetail/ExerciseDetailView.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import AVKit
+import UniformTypeIdentifiers
 
 struct ExerciseDetailView: View {
     @StateObject private var viewModel: ExerciseDetailViewModel
@@ -78,16 +80,28 @@ struct ExerciseDetailView: View {
     @ViewBuilder
     private var mediaView: some View {
         if let url = viewModel.exercise.mediaURL {
-            AsyncImage(url: url) { phase in
-                switch phase {
-                case .success(let image):
-                    image.resizable().scaledToFill().clipped()
-                default:
-                    Rectangle().fill(Theme.color.backgroundSecondary)
+            if mediaIsVideo(url) {
+                VideoPlayer(player: AVPlayer(url: url))
+                    .clipShape(RoundedRectangle(cornerRadius: Theme.radius.image))
+            } else {
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image.resizable().scaledToFill().clipped()
+                    default:
+                        Rectangle().fill(Theme.color.backgroundSecondary)
+                    }
                 }
+                .clipShape(RoundedRectangle(cornerRadius: Theme.radius.image))
             }
-            .clipShape(RoundedRectangle(cornerRadius: Theme.radius.image))
         }
+    }
+
+    private func mediaIsVideo(_ url: URL) -> Bool {
+        if let type = UTType(filenameExtension: url.pathExtension) {
+            return type.conforms(to: .movie)
+        }
+        return false
     }
 }
 

--- a/FitLink/Views/ExerciseDetail/ExerciseDetailView.swift
+++ b/FitLink/Views/ExerciseDetail/ExerciseDetailView.swift
@@ -82,16 +82,20 @@ struct ExerciseDetailView: View {
         if let url = viewModel.exercise.mediaURL {
             if mediaIsVideo(url) {
                 VideoPlayer(player: AVPlayer(url: url))
+                    .frame(height: 220)
                     .clipShape(RoundedRectangle(cornerRadius: Theme.radius.image))
             } else {
                 AsyncImage(url: url) { phase in
                     switch phase {
                     case .success(let image):
-                        image.resizable().scaledToFill().clipped()
+                        image.resizable()
+                            .aspectRatio(contentMode: .fit)
                     default:
                         Rectangle().fill(Theme.color.backgroundSecondary)
                     }
                 }
+                .frame(height: 220)
+                .clipped()
                 .clipShape(RoundedRectangle(cornerRadius: Theme.radius.image))
             }
         }

--- a/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
+++ b/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
@@ -14,115 +14,8 @@ struct ExerciseEditView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                List {
-                    Section(header: Text(NSLocalizedString("ExerciseEdit.Name", comment: ""))) {
-                        TextField("", text: $viewModel.name)
-                    }
-
-                Section(header: Text(NSLocalizedString("ExerciseEdit.Description", comment: ""))) {
-                    TextEditor(text: $viewModel.description)
-                        .frame(minHeight: 100)
-                }
-
-                Section(header: Text(NSLocalizedString("ExerciseEdit.Media", comment: ""))) {
-                    if let url = viewModel.mediaURL {
-                        mediaPreview(url)
-                        HStack {
-                            PhotosPicker(selection: $pickerItem, matching: [.images, .videos]) {
-                                Text(NSLocalizedString("ExerciseEdit.ReplaceMedia", comment: ""))
-                            }
-                            Spacer()
-                            Button(role: .destructive) {
-                                viewModel.removeMedia()
-                            } label: {
-                                Text(NSLocalizedString("ExerciseEdit.RemoveMedia", comment: ""))
-                            }
-                        }
-                    } else {
-                        PhotosPicker(selection: $pickerItem, matching: [.images, .videos]) {
-                            Text(NSLocalizedString("ExerciseEdit.MediaPlaceholder", comment: ""))
-                        }
-                    }
-                }
-
-                Section(header: Text(NSLocalizedString("ExerciseEdit.Variations", comment: ""))) {
-                    ForEach(viewModel.variations, id: \.self) { variation in
-                        Text(variation)
-                    }
-                    .onDelete(perform: viewModel.removeVariation)
-
-                    HStack {
-                        TextField(NSLocalizedString("ExerciseEdit.VariationPlaceholder", comment: ""), text: $viewModel.newVariation)
-                        Button(action: viewModel.addVariation) {
-                            Image(systemName: "plus.circle.fill")
-                        }
-                    }
-                }
-
-                Section(header: Text(NSLocalizedString("ExerciseEdit.MuscleGroups", comment: ""))) {
-                    ForEach(MuscleGroup.allStandardCases, id: \.self) { group in
-                        HStack {
-                            Text(group.displayName)
-                            Spacer()
-                            if viewModel.selectedGroups.contains(group) {
-                                Image(systemName: "checkmark")
-                            }
-                        }
-                        .contentShape(Rectangle())
-                        .onTapGesture { viewModel.toggleGroup(group) }
-                    }
-                }
-
-                Section(header: Text(NSLocalizedString("ExerciseEdit.MainMuscle", comment: ""))) {
-                    Picker("", selection: Binding(get: { viewModel.mainGroup ?? viewModel.selectedGroups.first }, set: { viewModel.mainGroup = $0 })) {
-                        ForEach(Array(viewModel.selectedGroups), id: \.self) { group in
-                            Text(group.displayName).tag(Optional(group))
-                        }
-                    }
-                }
-
-                Section(header: Text(NSLocalizedString("ExerciseEdit.Metrics", comment: ""))) {
-                    ForEach(viewModel.metrics.indices, id: \.self) { index in
-                        let metricBinding = $viewModel.metrics[index]
-                        VStack(alignment: .leading) {
-                            Picker(NSLocalizedString("ExerciseEdit.MetricType", comment: ""), selection: Binding(
-                                get: { metricBinding.wrappedValue.type },
-                                set: { newType in
-                                    metricBinding.wrappedValue.type = newType
-                                    if !newType.allowedUnits.contains(metricBinding.wrappedValue.unit ?? .repetition) {
-                                        metricBinding.wrappedValue.unit = newType.allowedUnits.first
-                                    }
-                                }
-                            )) {
-                                ForEach(ExerciseMetricType.allCases, id: \.self) { type in
-                                    Text(type.displayName).tag(type)
-                                }
-                            }
-                            if metricBinding.wrappedValue.type != .reps {
-                                Picker(NSLocalizedString("ExerciseEdit.Unit", comment: ""), selection: Binding(
-                                    get: { metricBinding.wrappedValue.unit },
-                                    set: { metricBinding.wrappedValue.unit = $0 }
-                                )) {
-                                    Text("-").tag(UnitType?.none)
-                                    ForEach(metricBinding.wrappedValue.type.allowedUnits, id: \.self) { unit in
-                                        Text(unit.displayName).tag(Optional(unit))
-                                    }
-                                }
-                            } else {
-                                Text(UnitType.repetition.displayName)
-                                    .font(Theme.font.caption)
-                                    .foregroundColor(Theme.color.textSecondary)
-                            }
-                            Toggle(NSLocalizedString("ExerciseEdit.Required", comment: ""), isOn: metricBinding.isRequired)
-                        }
-                    }
-                    .onDelete(perform: viewModel.removeMetric)
-                    Button(NSLocalizedString("ExerciseEdit.AddMetric", comment: "")) {
-                        viewModel.addMetric()
-                    }
-                }
-                } //: List
-                .listStyle(.insetGrouped)
+                formList
+                    .listStyle(.insetGrouped)
 
                 if viewModel.isProcessingMedia {
                     ProgressView()
@@ -149,7 +42,7 @@ struct ExerciseEditView: View {
                 guard let item = newValue else { return }
                 Task {
                     if let url = try? await item.loadTransferable(type: URL.self) {
-                        await viewModel.onMediaSelected(tempURL: url)
+                        viewModel.onMediaSelected(tempURL: url)
                     }
                     pickerItem = nil
                 }
@@ -161,6 +54,112 @@ struct ExerciseEditView: View {
                 Button("OK", role: .cancel) { }
             }
         } //: NavigationStack
+    }
+
+    private var formList: some View {
+        List {
+            nameSection
+            descriptionSection
+            mediaSection
+            variationsSection
+            groupsSection
+            mainMuscleSection
+            metricsSection
+        } //: List
+    }
+
+    @ViewBuilder private var nameSection: some View {
+        Section(header: Text(NSLocalizedString("ExerciseEdit.Name", comment: ""))) {
+            TextField("", text: $viewModel.name)
+        }
+    }
+
+    @ViewBuilder private var descriptionSection: some View {
+        Section(header: Text(NSLocalizedString("ExerciseEdit.Description", comment: ""))) {
+            TextEditor(text: $viewModel.description)
+                .frame(minHeight: 100)
+        }
+    }
+
+    @ViewBuilder private var mediaSection: some View {
+        Section(header: Text(NSLocalizedString("ExerciseEdit.Media", comment: ""))) {
+            if let url = viewModel.mediaURL {
+                mediaPreview(url)
+                HStack {
+                    PhotosPicker(selection: $pickerItem, matching: [.images, .videos]) {
+                        Text(NSLocalizedString("ExerciseEdit.ReplaceMedia", comment: ""))
+                    }
+                    Spacer()
+                    Button(role: .destructive) {
+                        viewModel.removeMedia()
+                    } label: {
+                        Text(NSLocalizedString("ExerciseEdit.RemoveMedia", comment: ""))
+                    }
+                }
+            } else {
+                PhotosPicker(selection: $pickerItem, matching: [.images, .videos]) {
+                    Text(NSLocalizedString("ExerciseEdit.MediaPlaceholder", comment: ""))
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private var variationsSection: some View {
+        Section(header: Text(NSLocalizedString("ExerciseEdit.Variations", comment: ""))) {
+            ForEach(viewModel.variations, id: \.self) { variation in
+                Text(variation)
+            }
+            .onDelete(perform: viewModel.removeVariation)
+
+            HStack {
+                TextField(NSLocalizedString("ExerciseEdit.VariationPlaceholder", comment: ""), text: $viewModel.newVariation)
+                Button(action: viewModel.addVariation) {
+                    Image(systemName: "plus.circle.fill")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private var groupsSection: some View {
+        Section(header: Text(NSLocalizedString("ExerciseEdit.MuscleGroups", comment: ""))) {
+            ForEach(MuscleGroup.allStandardCases, id: \.self) { group in
+                HStack {
+                    Text(group.displayName)
+                    Spacer()
+                    if viewModel.selectedGroups.contains(group) {
+                        Image(systemName: "checkmark")
+                    }
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { viewModel.toggleGroup(group) }
+            }
+        }
+    }
+
+    @ViewBuilder private var mainMuscleSection: some View {
+        let selection = Binding<MuscleGroup?>(
+            get: { viewModel.mainGroup ?? viewModel.selectedGroups.first },
+            set: { viewModel.mainGroup = $0 }
+        )
+        Section(header: Text(NSLocalizedString("ExerciseEdit.MainMuscle", comment: ""))) {
+            Picker("", selection: selection) {
+                ForEach(Array(viewModel.selectedGroups), id: \.self) { group in
+                    Text(group.displayName).tag(Optional(group))
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private var metricsSection: some View {
+        Section(header: Text(NSLocalizedString("ExerciseEdit.Metrics", comment: ""))) {
+            ForEach(viewModel.metrics.indices, id: \.self) { index in
+                MetricRow(metric: $viewModel.metrics[index])
+            }
+            .onDelete(perform: viewModel.removeMetric)
+            Button(NSLocalizedString("ExerciseEdit.AddMetric", comment: "")) {
+                viewModel.addMetric()
+            }
+        }
     }
 
     @ViewBuilder
@@ -181,6 +180,47 @@ struct ExerciseEditView: View {
             .clipShape(RoundedRectangle(cornerRadius: Theme.radius.image))
         }
     }
+
+    private struct MetricRow: View {
+        @Binding var metric: ExerciseMetric
+
+        var body: some View {
+            VStack(alignment: .leading) {
+                metricTypePicker
+                unitPicker
+                Toggle(NSLocalizedString("ExerciseEdit.Required", comment: ""), isOn: $metric.isRequired)
+            } //: VStack
+        }
+
+        private var metricTypePicker: some View {
+            Picker(NSLocalizedString("ExerciseEdit.MetricType", comment: ""), selection: $metric.type) {
+                ForEach(ExerciseMetricType.allCases, id: \.self) { type in
+                    Text(type.displayName).tag(type)
+                }
+            }
+            .onChange(of: metric.type) { newType in
+                if !newType.allowedUnits.contains(metric.unit ?? .repetition) {
+                    metric.unit = newType.allowedUnits.first
+                }
+            }
+        }
+
+        @ViewBuilder private var unitPicker: some View {
+            if metric.type != .reps {
+                Picker(NSLocalizedString("ExerciseEdit.Unit", comment: ""), selection: $metric.unit) {
+                    Text("-").tag(UnitType?.none)
+                    ForEach(metric.type.allowedUnits, id: \.self) { unit in
+                        Text(unit.displayName).tag(Optional(unit))
+                    }
+                }
+            } else {
+                Text(UnitType.repetition.displayName)
+                    .font(Theme.font.caption)
+                    .foregroundColor(Theme.color.textSecondary)
+            }
+        }
+    }
+
 }
 
 #Preview {

--- a/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
+++ b/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
@@ -87,22 +87,24 @@ struct ExerciseEditView: View {
 
     @ViewBuilder private var mediaSection: some View {
         Section {
-            if let url = viewModel.mediaURL {
-                mediaPreview(url)
-                HStack {
+            Group {
+                if let url = viewModel.mediaURL {
+                    mediaPreview(url)
+                    HStack {
+                        PhotosPicker(selection: $pickerItem, matching: [.images, .videos]) {
+                            Text(NSLocalizedString("ExerciseEdit.ReplaceMedia", comment: ""))
+                        }
+                        Spacer()
+                        Button(role: .destructive) {
+                            viewModel.removeMedia()
+                        } label: {
+                            Text(NSLocalizedString("ExerciseEdit.RemoveMedia", comment: ""))
+                        }
+                    }
+                } else {
                     PhotosPicker(selection: $pickerItem, matching: [.images, .videos]) {
-                        Text(NSLocalizedString("ExerciseEdit.ReplaceMedia", comment: ""))
+                        Text(NSLocalizedString("ExerciseEdit.MediaPlaceholder", comment: ""))
                     }
-                    Spacer()
-                    Button(role: .destructive) {
-                        viewModel.removeMedia()
-                    } label: {
-                        Text(NSLocalizedString("ExerciseEdit.RemoveMedia", comment: ""))
-                    }
-                }
-            } else {
-                PhotosPicker(selection: $pickerItem, matching: [.images, .videos]) {
-                    Text(NSLocalizedString("ExerciseEdit.MediaPlaceholder", comment: ""))
                 }
             }
         } header: {
@@ -112,15 +114,17 @@ struct ExerciseEditView: View {
 
     @ViewBuilder private var variationsSection: some View {
         Section {
-            ForEach(viewModel.variations, id: \.self) { variation in
-                Text(variation)
-            }
-            .onDelete(perform: viewModel.removeVariation)
+            Group {
+                ForEach(viewModel.variations, id: \.self) { variation in
+                    Text(variation)
+                }
+                .onDelete(perform: viewModel.removeVariation)
 
-            HStack {
-                TextField(NSLocalizedString("ExerciseEdit.VariationPlaceholder", comment: ""), text: $viewModel.newVariation)
-                Button(action: viewModel.addVariation) {
-                    Image(systemName: "plus.circle.fill")
+                HStack {
+                    TextField(NSLocalizedString("ExerciseEdit.VariationPlaceholder", comment: ""), text: $viewModel.newVariation)
+                    Button(action: viewModel.addVariation) {
+                        Image(systemName: "plus.circle.fill")
+                    }
                 }
             }
         } header: {
@@ -164,12 +168,14 @@ struct ExerciseEditView: View {
 
     @ViewBuilder private var metricsSection: some View {
         Section {
-            ForEach(viewModel.metrics.indices, id: \.self) { index in
-                MetricRow(metric: $viewModel.metrics[index])
-            }
-            .onDelete(perform: viewModel.removeMetric)
-            Button(NSLocalizedString("ExerciseEdit.AddMetric", comment: "")) {
-                viewModel.addMetric()
+            Group {
+                ForEach(viewModel.metrics.indices, id: \.self) { index in
+                    MetricRow(metric: $viewModel.metrics[index])
+                }
+                .onDelete(perform: viewModel.removeMetric)
+                Button(NSLocalizedString("ExerciseEdit.AddMetric", comment: "")) {
+                    viewModel.addMetric()
+                }
             }
         } header: {
             Text(NSLocalizedString("ExerciseEdit.Metrics", comment: ""))

--- a/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
+++ b/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
@@ -91,9 +91,16 @@ struct ExerciseEditView: View {
                 if let url = viewModel.mediaURL {
                     mediaPreview(url)
                     HStack {
-                    PhotosPicker(selection: $pickerItem, matching: .any(of: [.images, .videos])) {
-                        Text(NSLocalizedString("ExerciseEdit.ReplaceMedia", comment: ""))
-                    }
+                        PhotosPicker(selection: $pickerItem, matching: .any(of: [.images, .videos])) {
+                            Text(NSLocalizedString("ExerciseEdit.ReplaceMedia", comment: ""))
+                        }
+                        if viewModel.errorMessage != nil {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(.red)
+                        } else {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(.green)
+                        }
                         Spacer()
                         Button(role: .destructive) {
                             viewModel.removeMedia()
@@ -102,8 +109,14 @@ struct ExerciseEditView: View {
                         }
                     }
                 } else {
-                    PhotosPicker(selection: $pickerItem, matching: .any(of: [.images, .videos])) {
-                        Text(NSLocalizedString("ExerciseEdit.MediaPlaceholder", comment: ""))
+                    HStack {
+                        PhotosPicker(selection: $pickerItem, matching: .any(of: [.images, .videos])) {
+                            Text(NSLocalizedString("ExerciseEdit.MediaPlaceholder", comment: ""))
+                        }
+                        if viewModel.errorMessage != nil {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(.red)
+                        }
                     }
                 }
             }

--- a/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
+++ b/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
@@ -91,9 +91,9 @@ struct ExerciseEditView: View {
                 if let url = viewModel.mediaURL {
                     mediaPreview(url)
                     HStack {
-                        PhotosPicker(selection: $pickerItem, matching: [.images, .videos]) {
-                            Text(NSLocalizedString("ExerciseEdit.ReplaceMedia", comment: ""))
-                        }
+                    PhotosPicker(selection: $pickerItem, matching: .any(of: [.images, .videos])) {
+                        Text(NSLocalizedString("ExerciseEdit.ReplaceMedia", comment: ""))
+                    }
                         Spacer()
                         Button(role: .destructive) {
                             viewModel.removeMedia()
@@ -102,7 +102,7 @@ struct ExerciseEditView: View {
                         }
                     }
                 } else {
-                    PhotosPicker(selection: $pickerItem, matching: [.images, .videos]) {
+                    PhotosPicker(selection: $pickerItem, matching: .any(of: [.images, .videos])) {
                         Text(NSLocalizedString("ExerciseEdit.MediaPlaceholder", comment: ""))
                     }
                 }

--- a/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
+++ b/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
@@ -69,20 +69,24 @@ struct ExerciseEditView: View {
     }
 
     @ViewBuilder private var nameSection: some View {
-        Section(header: Text(NSLocalizedString("ExerciseEdit.Name", comment: ""))) {
+        Section {
             TextField("", text: $viewModel.name)
+        } header: {
+            Text(NSLocalizedString("ExerciseEdit.Name", comment: ""))
         }
     }
 
     @ViewBuilder private var descriptionSection: some View {
-        Section(header: Text(NSLocalizedString("ExerciseEdit.Description", comment: ""))) {
+        Section {
             TextEditor(text: $viewModel.description)
                 .frame(minHeight: 100)
+        } header: {
+            Text(NSLocalizedString("ExerciseEdit.Description", comment: ""))
         }
     }
 
     @ViewBuilder private var mediaSection: some View {
-        Section(header: Text(NSLocalizedString("ExerciseEdit.Media", comment: ""))) {
+        Section {
             if let url = viewModel.mediaURL {
                 mediaPreview(url)
                 HStack {
@@ -101,11 +105,13 @@ struct ExerciseEditView: View {
                     Text(NSLocalizedString("ExerciseEdit.MediaPlaceholder", comment: ""))
                 }
             }
+        } header: {
+            Text(NSLocalizedString("ExerciseEdit.Media", comment: ""))
         }
     }
 
     @ViewBuilder private var variationsSection: some View {
-        Section(header: Text(NSLocalizedString("ExerciseEdit.Variations", comment: ""))) {
+        Section {
             ForEach(viewModel.variations, id: \.self) { variation in
                 Text(variation)
             }
@@ -117,11 +123,13 @@ struct ExerciseEditView: View {
                     Image(systemName: "plus.circle.fill")
                 }
             }
+        } header: {
+            Text(NSLocalizedString("ExerciseEdit.Variations", comment: ""))
         }
     }
 
     @ViewBuilder private var groupsSection: some View {
-        Section(header: Text(NSLocalizedString("ExerciseEdit.MuscleGroups", comment: ""))) {
+        Section {
             ForEach(MuscleGroup.allStandardCases, id: \.self) { group in
                 HStack {
                     Text(group.displayName)
@@ -133,6 +141,8 @@ struct ExerciseEditView: View {
                 .contentShape(Rectangle())
                 .onTapGesture { viewModel.toggleGroup(group) }
             }
+        } header: {
+            Text(NSLocalizedString("ExerciseEdit.MuscleGroups", comment: ""))
         }
     }
 
@@ -141,17 +151,19 @@ struct ExerciseEditView: View {
             get: { viewModel.mainGroup ?? viewModel.selectedGroups.first },
             set: { viewModel.mainGroup = $0 }
         )
-        Section(header: Text(NSLocalizedString("ExerciseEdit.MainMuscle", comment: ""))) {
+        Section {
             Picker("", selection: selection) {
                 ForEach(Array(viewModel.selectedGroups), id: \.self) { group in
                     Text(group.displayName).tag(Optional(group))
                 }
             }
+        } header: {
+            Text(NSLocalizedString("ExerciseEdit.MainMuscle", comment: ""))
         }
     }
 
     @ViewBuilder private var metricsSection: some View {
-        Section(header: Text(NSLocalizedString("ExerciseEdit.Metrics", comment: ""))) {
+        Section {
             ForEach(viewModel.metrics.indices, id: \.self) { index in
                 MetricRow(metric: $viewModel.metrics[index])
             }
@@ -159,6 +171,8 @@ struct ExerciseEditView: View {
             Button(NSLocalizedString("ExerciseEdit.AddMetric", comment: "")) {
                 viewModel.addMetric()
             }
+        } header: {
+            Text(NSLocalizedString("ExerciseEdit.Metrics", comment: ""))
         }
     }
 

--- a/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
+++ b/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
@@ -69,24 +69,20 @@ struct ExerciseEditView: View {
     }
 
     @ViewBuilder private var nameSection: some View {
-        Section {
+        Section(header: Text(NSLocalizedString("ExerciseEdit.Name", comment: ""))) {
             TextField("", text: $viewModel.name)
-        } header: {
-            Text(NSLocalizedString("ExerciseEdit.Name", comment: ""))
         }
     }
 
     @ViewBuilder private var descriptionSection: some View {
-        Section {
+        Section(header: Text(NSLocalizedString("ExerciseEdit.Description", comment: ""))) {
             TextEditor(text: $viewModel.description)
                 .frame(minHeight: 100)
-        } header: {
-            Text(NSLocalizedString("ExerciseEdit.Description", comment: ""))
         }
     }
 
     @ViewBuilder private var mediaSection: some View {
-        Section {
+        Section(header: Text(NSLocalizedString("ExerciseEdit.Media", comment: ""))) {
             if let url = viewModel.mediaURL {
                 mediaPreview(url)
                 HStack {
@@ -105,13 +101,11 @@ struct ExerciseEditView: View {
                     Text(NSLocalizedString("ExerciseEdit.MediaPlaceholder", comment: ""))
                 }
             }
-        } header: {
-            Text(NSLocalizedString("ExerciseEdit.Media", comment: ""))
         }
     }
 
     @ViewBuilder private var variationsSection: some View {
-        Section {
+        Section(header: Text(NSLocalizedString("ExerciseEdit.Variations", comment: ""))) {
             ForEach(viewModel.variations, id: \.self) { variation in
                 Text(variation)
             }
@@ -123,13 +117,11 @@ struct ExerciseEditView: View {
                     Image(systemName: "plus.circle.fill")
                 }
             }
-        } header: {
-            Text(NSLocalizedString("ExerciseEdit.Variations", comment: ""))
         }
     }
 
     @ViewBuilder private var groupsSection: some View {
-        Section {
+        Section(header: Text(NSLocalizedString("ExerciseEdit.MuscleGroups", comment: ""))) {
             ForEach(MuscleGroup.allStandardCases, id: \.self) { group in
                 HStack {
                     Text(group.displayName)
@@ -141,8 +133,6 @@ struct ExerciseEditView: View {
                 .contentShape(Rectangle())
                 .onTapGesture { viewModel.toggleGroup(group) }
             }
-        } header: {
-            Text(NSLocalizedString("ExerciseEdit.MuscleGroups", comment: ""))
         }
     }
 
@@ -151,19 +141,17 @@ struct ExerciseEditView: View {
             get: { viewModel.mainGroup ?? viewModel.selectedGroups.first },
             set: { viewModel.mainGroup = $0 }
         )
-        Section {
+        Section(header: Text(NSLocalizedString("ExerciseEdit.MainMuscle", comment: ""))) {
             Picker("", selection: selection) {
                 ForEach(Array(viewModel.selectedGroups), id: \.self) { group in
                     Text(group.displayName).tag(Optional(group))
                 }
             }
-        } header: {
-            Text(NSLocalizedString("ExerciseEdit.MainMuscle", comment: ""))
         }
     }
 
     @ViewBuilder private var metricsSection: some View {
-        Section {
+        Section(header: Text(NSLocalizedString("ExerciseEdit.Metrics", comment: ""))) {
             ForEach(viewModel.metrics.indices, id: \.self) { index in
                 MetricRow(metric: $viewModel.metrics[index])
             }
@@ -171,8 +159,6 @@ struct ExerciseEditView: View {
             Button(NSLocalizedString("ExerciseEdit.AddMetric", comment: "")) {
                 viewModel.addMetric()
             }
-        } header: {
-            Text(NSLocalizedString("ExerciseEdit.Metrics", comment: ""))
         }
     }
 

--- a/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
+++ b/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
@@ -38,7 +38,7 @@ struct ExerciseEditView: View {
                     .disabled(!viewModel.canSave)
                 }
             }
-            .onChange(of: pickerItem) { newValue in
+            .onChange(of: pickerItem) { _, newValue in
                 guard let item = newValue else { return }
                 Task {
                     if let url = try? await item.loadTransferable(type: URL.self) {
@@ -69,20 +69,24 @@ struct ExerciseEditView: View {
     }
 
     @ViewBuilder private var nameSection: some View {
-        Section(header: Text(NSLocalizedString("ExerciseEdit.Name", comment: ""))) {
+        Section {
             TextField("", text: $viewModel.name)
+        } header: {
+            Text(NSLocalizedString("ExerciseEdit.Name", comment: ""))
         }
     }
 
     @ViewBuilder private var descriptionSection: some View {
-        Section(header: Text(NSLocalizedString("ExerciseEdit.Description", comment: ""))) {
+        Section {
             TextEditor(text: $viewModel.description)
                 .frame(minHeight: 100)
+        } header: {
+            Text(NSLocalizedString("ExerciseEdit.Description", comment: ""))
         }
     }
 
     @ViewBuilder private var mediaSection: some View {
-        Section(header: Text(NSLocalizedString("ExerciseEdit.Media", comment: ""))) {
+        Section {
             if let url = viewModel.mediaURL {
                 mediaPreview(url)
                 HStack {
@@ -101,11 +105,13 @@ struct ExerciseEditView: View {
                     Text(NSLocalizedString("ExerciseEdit.MediaPlaceholder", comment: ""))
                 }
             }
+        } header: {
+            Text(NSLocalizedString("ExerciseEdit.Media", comment: ""))
         }
     }
 
     @ViewBuilder private var variationsSection: some View {
-        Section(header: Text(NSLocalizedString("ExerciseEdit.Variations", comment: ""))) {
+        Section {
             ForEach(viewModel.variations, id: \.self) { variation in
                 Text(variation)
             }
@@ -117,11 +123,13 @@ struct ExerciseEditView: View {
                     Image(systemName: "plus.circle.fill")
                 }
             }
+        } header: {
+            Text(NSLocalizedString("ExerciseEdit.Variations", comment: ""))
         }
     }
 
     @ViewBuilder private var groupsSection: some View {
-        Section(header: Text(NSLocalizedString("ExerciseEdit.MuscleGroups", comment: ""))) {
+        Section {
             ForEach(MuscleGroup.allStandardCases, id: \.self) { group in
                 HStack {
                     Text(group.displayName)
@@ -133,6 +141,8 @@ struct ExerciseEditView: View {
                 .contentShape(Rectangle())
                 .onTapGesture { viewModel.toggleGroup(group) }
             }
+        } header: {
+            Text(NSLocalizedString("ExerciseEdit.MuscleGroups", comment: ""))
         }
     }
 
@@ -141,17 +151,19 @@ struct ExerciseEditView: View {
             get: { viewModel.mainGroup ?? viewModel.selectedGroups.first },
             set: { viewModel.mainGroup = $0 }
         )
-        Section(header: Text(NSLocalizedString("ExerciseEdit.MainMuscle", comment: ""))) {
+        Section {
             Picker("", selection: selection) {
                 ForEach(Array(viewModel.selectedGroups), id: \.self) { group in
                     Text(group.displayName).tag(Optional(group))
                 }
             }
+        } header: {
+            Text(NSLocalizedString("ExerciseEdit.MainMuscle", comment: ""))
         }
     }
 
     @ViewBuilder private var metricsSection: some View {
-        Section(header: Text(NSLocalizedString("ExerciseEdit.Metrics", comment: ""))) {
+        Section {
             ForEach(viewModel.metrics.indices, id: \.self) { index in
                 MetricRow(metric: $viewModel.metrics[index])
             }
@@ -159,6 +171,8 @@ struct ExerciseEditView: View {
             Button(NSLocalizedString("ExerciseEdit.AddMetric", comment: "")) {
                 viewModel.addMetric()
             }
+        } header: {
+            Text(NSLocalizedString("ExerciseEdit.Metrics", comment: ""))
         }
     }
 
@@ -198,7 +212,7 @@ struct ExerciseEditView: View {
                     Text(type.displayName).tag(type)
                 }
             }
-            .onChange(of: metric.type) { newType in
+            .onChange(of: metric.type) { _, newType in
                 if !newType.allowedUnits.contains(metric.unit ?? .repetition) {
                     metric.unit = newType.allowedUnits.first
                 }

--- a/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
+++ b/FitLink/Views/ExerciseEdit/ExerciseEditView.swift
@@ -234,12 +234,14 @@ struct ExerciseEditView: View {
             AsyncImage(url: url) { phase in
                 switch phase {
                 case .success(let image):
-                    image.resizable().scaledToFill()
+                    image.resizable()
+                        .aspectRatio(contentMode: .fit)
                 default:
                     Rectangle().fill(Theme.color.backgroundSecondary)
                 }
             }
             .frame(height: 200)
+            .clipped()
             .clipShape(RoundedRectangle(cornerRadius: Theme.radius.image))
         }
     }


### PR DESCRIPTION
## Summary
- create `ExerciseMediaManager` to handle file operations
- extend `AppDataStore` with async media management APIs and cleanup support
- update `ExerciseEditViewModel` to use the new APIs for attaching/removing media

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_685fe278db10833094bfd82e26e70795