### PR TITLE
Enable fullscreen media playback

### DIFF
--- a/FitLink/Helpers/URL+MediaType.swift
+++ b/FitLink/Helpers/URL+MediaType.swift
@@ -1,0 +1,15 @@
+import Foundation
+import UniformTypeIdentifiers
+
+extension URL {
+    var isVideo: Bool {
+        if let type = UTType(filenameExtension: pathExtension) {
+            return type.conforms(to: .movie)
+        }
+        return false
+    }
+}
+
+extension URL: Identifiable {
+    public var id: URL { self }
+}

--- a/FitLink/UIAtoms/VideoPlayerView.swift
+++ b/FitLink/UIAtoms/VideoPlayerView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import AVFoundation
+
+/// Lightweight video container without playback controls.
+struct VideoPlayerView: UIViewRepresentable {
+    let player: AVPlayer
+
+    func makeUIView(context: Context) -> PlayerView {
+        let view = PlayerView()
+        view.playerLayer.videoGravity = .resizeAspect
+        view.playerLayer.player = player
+        return view
+    }
+
+    func updateUIView(_ uiView: PlayerView, context: Context) {
+        uiView.playerLayer.player = player
+    }
+
+    final class PlayerView: UIView {
+        override static var layerClass: AnyClass { AVPlayerLayer.self }
+        var playerLayer: AVPlayerLayer { layer as! AVPlayerLayer }
+    }
+}
+
+#if DEBUG
+#Preview {
+    VideoPlayerView(player: AVPlayer())
+        .frame(height: 200)
+        .padding()
+}
+#endif

--- a/FitLink/Views/ExerciseDetail/ExerciseDetailView.swift
+++ b/FitLink/Views/ExerciseDetail/ExerciseDetailView.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import AVKit
+import AVFoundation
 import UniformTypeIdentifiers
 
 struct ExerciseDetailView: View {
@@ -75,15 +75,19 @@ struct ExerciseDetailView: View {
         .sheet(isPresented: $viewModel.showEdit) {
             ExerciseEditView(exercise: viewModel.exercise)
         }
+        .fullScreenCover(item: $viewModel.fullScreenMediaURL) { url in
+            FullScreenMediaView(url: url)
+        }
     }
 
     @ViewBuilder
     private var mediaView: some View {
         if let url = viewModel.exercise.mediaURL {
-            if mediaIsVideo(url) {
-                VideoPlayer(player: AVPlayer(url: url))
+            if url.isVideo {
+                VideoPlayerView(player: AVPlayer(url: url))
                     .frame(height: 220)
                     .clipShape(RoundedRectangle(cornerRadius: Theme.radius.image))
+                    .onTapGesture { viewModel.mediaTapped() }
             } else {
                 AsyncImage(url: url) { phase in
                     switch phase {
@@ -97,15 +101,9 @@ struct ExerciseDetailView: View {
                 .frame(height: 220)
                 .clipped()
                 .clipShape(RoundedRectangle(cornerRadius: Theme.radius.image))
+                .onTapGesture { viewModel.mediaTapped() }
             }
         }
-    }
-
-    private func mediaIsVideo(_ url: URL) -> Bool {
-        if let type = UTType(filenameExtension: url.pathExtension) {
-            return type.conforms(to: .movie)
-        }
-        return false
     }
 }
 

--- a/FitLink/Views/ExerciseDetail/ExerciseDetailView.swift
+++ b/FitLink/Views/ExerciseDetail/ExerciseDetailView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import AVFoundation
-import UniformTypeIdentifiers
 
 struct ExerciseDetailView: View {
     @StateObject private var viewModel: ExerciseDetailViewModel
@@ -83,8 +82,8 @@ struct ExerciseDetailView: View {
     @ViewBuilder
     private var mediaView: some View {
         if let url = viewModel.exercise.mediaURL {
-            if url.isVideo {
-                VideoPlayerView(player: AVPlayer(url: url))
+            if let player = viewModel.previewPlayer {
+                VideoPlayerView(player: player)
                     .frame(height: 220)
                     .clipShape(RoundedRectangle(cornerRadius: Theme.radius.image))
                     .onTapGesture { viewModel.mediaTapped() }

--- a/FitLink/Views/ExerciseDetail/ExerciseDetailViewModel.swift
+++ b/FitLink/Views/ExerciseDetail/ExerciseDetailViewModel.swift
@@ -1,11 +1,13 @@
 import Foundation
 import Combine
+import AVFoundation
 
 @MainActor
 final class ExerciseDetailViewModel: ObservableObject {
     @Published var exercise: Exercise
     @Published var showEdit: Bool = false
     @Published var fullScreenMediaURL: URL?
+    @Published private(set) var previewPlayer: AVPlayer?
 
     private let dataStore: AppDataStore
     private let exerciseId: UUID
@@ -15,10 +17,16 @@ final class ExerciseDetailViewModel: ObservableObject {
         self.exerciseId = exerciseId
         self.dataStore = dataStore
         self.exercise = dataStore.exercises.first { $0.id == exerciseId }!
+        self.setupPreviewPlayer(with: exercise.mediaURL)
 
         dataStore.$exercises
             .compactMap { $0.first(where: { $0.id == exerciseId }) }
-            .assign(to: &$exercise)
+            .sink { [weak self] updated in
+                guard let self else { return }
+                self.exercise = updated
+                self.setupPreviewPlayer(with: updated.mediaURL)
+            }
+            .store(in: &cancellables)
     }
 
     func editTapped() {
@@ -27,6 +35,25 @@ final class ExerciseDetailViewModel: ObservableObject {
 
     func mediaTapped() {
         fullScreenMediaURL = exercise.mediaURL
+    }
+
+    private func setupPreviewPlayer(with url: URL?) {
+        guard let url = url, url.isVideo else {
+            previewPlayer = nil
+            return
+        }
+
+        if let player = previewPlayer,
+           let assetURL = (player.currentItem?.asset as? AVURLAsset)?.url,
+           assetURL == url {
+            return
+        }
+
+        let player = previewPlayer ?? AVPlayer()
+        player.replaceCurrentItem(with: AVPlayerItem(url: url))
+        player.actionAtItemEnd = .pause
+        player.seek(to: .zero)
+        previewPlayer = player
     }
 }
 

--- a/FitLink/Views/ExerciseDetail/ExerciseDetailViewModel.swift
+++ b/FitLink/Views/ExerciseDetail/ExerciseDetailViewModel.swift
@@ -5,6 +5,7 @@ import Combine
 final class ExerciseDetailViewModel: ObservableObject {
     @Published var exercise: Exercise
     @Published var showEdit: Bool = false
+    @Published var fullScreenMediaURL: URL?
 
     private let dataStore: AppDataStore
     private let exerciseId: UUID
@@ -22,6 +23,10 @@ final class ExerciseDetailViewModel: ObservableObject {
 
     func editTapped() {
         showEdit = true
+    }
+
+    func mediaTapped() {
+        fullScreenMediaURL = exercise.mediaURL
     }
 }
 

--- a/FitLink/Views/ExerciseDetail/FullScreenMediaView.swift
+++ b/FitLink/Views/ExerciseDetail/FullScreenMediaView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import AVFoundation
+
+struct FullScreenMediaView: View {
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var viewModel: FullScreenMediaViewModel
+
+    init(url: URL) {
+        _viewModel = StateObject(wrappedValue: FullScreenMediaViewModel(url: url))
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+            if viewModel.isVideo {
+                VideoPlayerView(player: viewModel.player)
+                    .onTapGesture { dismiss() }
+            } else {
+                AsyncImage(url: viewModel.url) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image.resizable()
+                            .aspectRatio(contentMode: .fit)
+                    default:
+                        Rectangle().fill(Color.black)
+                    }
+                }
+                .onTapGesture { dismiss() }
+            }
+        }
+        .onAppear { viewModel.start() }
+        .onDisappear { viewModel.stop() }
+    }
+}
+
+#if DEBUG
+#Preview {
+    FullScreenMediaView(url: URL(fileURLWithPath: "/dev/null"))
+}
+#endif

--- a/FitLink/Views/ExerciseDetail/FullScreenMediaViewModel.swift
+++ b/FitLink/Views/ExerciseDetail/FullScreenMediaViewModel.swift
@@ -1,0 +1,33 @@
+import Foundation
+import AVFoundation
+
+@MainActor
+final class FullScreenMediaViewModel: ObservableObject {
+    let url: URL
+    let isVideo: Bool
+    let player: AVQueuePlayer
+    private var looper: AVPlayerLooper?
+
+    init(url: URL) {
+        self.url = url
+        self.isVideo = url.isVideo
+        self.player = AVQueuePlayer()
+        if isVideo {
+            let item = AVPlayerItem(url: url)
+            self.looper = AVPlayerLooper(player: player, templateItem: item)
+            player.actionAtItemEnd = .none
+        }
+    }
+
+    func start() {
+        if isVideo {
+            player.play()
+        }
+    }
+
+    func stop() {
+        if isVideo {
+            player.pause()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `URL` helper to detect video type
- create `VideoPlayerView` without system controls
- implement fullscreen media viewer with looped video playback
- open media fullscreen from `ExerciseDetailView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68607638946483308740ba5c51476fcf